### PR TITLE
feat: add automated AI daily pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Never put real keys in this file.
+DASHSCOPE_API_KEY=
+DASHSCOPE_BASE_URL=https://YOUR_WORKSPACE_ID.cn-beijing.maas.aliyuncs.com/compatible-mode/v1
+DEEPSEEK_API_KEY=
+GITHUB_TOKEN=
+GITHUB_REPOSITORY=wjy9902/ai-daily
+SITE_BASE_URL=https://wjy9902.github.io/ai-daily

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install locked dependencies
+        run: |
+          python -m pip install uv==0.9.28
+          uv sync --frozen --all-groups
+      - name: Lint
+        run: uv run --frozen ruff check .
+      - name: Type check
+        run: |
+          uv run --frozen mypy src
+          uv run --frozen pyright
+      - name: Test
+        run: uv run --frozen pytest

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,148 @@
+name: Generate AI Daily
+
+on:
+  schedule:
+    - cron: "20 20 * * *"
+    - cron: "5 21 * * *"
+    - cron: "45 21 * * *"
+  workflow_dispatch:
+    inputs:
+      target_date:
+        description: "Asia/Shanghai date (YYYY-MM-DD); blank means today"
+        required: false
+        type: string
+      mode:
+        description: "Run mode"
+        required: true
+        default: dry-run
+        type: choice
+        options:
+          - dry-run
+          - publish
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: ai-daily-publication-lock
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      deploy: ${{ steps.decision.outputs.deploy }}
+      verify: ${{ steps.decision.outputs.verify }}
+      target_date: ${{ steps.target.outputs.date }}
+    env:
+      DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}
+      DASHSCOPE_BASE_URL: ${{ secrets.DASHSCOPE_BASE_URL }}
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      GITHUB_TOKEN: ${{ github.token }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      SITE_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install locked dependencies
+        run: |
+          python -m pip install uv==0.9.28
+          uv sync --frozen --no-dev
+      - id: target
+        name: Resolve target date
+        env:
+          INPUT_DATE: ${{ inputs.target_date }}
+        run: |
+          if [ -n "$INPUT_DATE" ]; then
+            DATE="$INPUT_DATE"
+          else
+            DATE=$(TZ=Asia/Shanghai date +%F)
+          fi
+          python -c 'import datetime,sys; datetime.date.fromisoformat(sys.argv[1])' "$DATE"
+          echo "date=$DATE" >> "$GITHUB_OUTPUT"
+      - id: decision
+        name: Generate or recover
+        env:
+          TARGET_DATE: ${{ steps.target.outputs.date }}
+          SCHEDULE: ${{ github.event.schedule }}
+          MANUAL_MODE: ${{ inputs.mode }}
+        run: |
+          if [ "$SCHEDULE" = "45 21 * * *" ]; then
+            if uv run --frozen ai-daily verify --date "$TARGET_DATE"; then
+              echo "deploy=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "deploy=true" >> "$GITHUB_OUTPUT"
+            fi
+            echo "verify=true" >> "$GITHUB_OUTPUT"
+          elif [ "$SCHEDULE" = "5 21 * * *" ]; then
+            if uv run --frozen ai-daily verify --date "$TARGET_DATE"; then
+              echo "deploy=false" >> "$GITHUB_OUTPUT"
+            elif uv run --frozen ai-daily issue-exists --date "$TARGET_DATE"; then
+              echo "deploy=true" >> "$GITHUB_OUTPUT"
+            else
+              uv run --frozen ai-daily run --date "$TARGET_DATE" --mode publish
+              echo "deploy=true" >> "$GITHUB_OUTPUT"
+            fi
+            echo "verify=true" >> "$GITHUB_OUTPUT"
+          elif [ "${MANUAL_MODE:-publish}" = "dry-run" ]; then
+            uv run --frozen ai-daily run --date "$TARGET_DATE" --mode dry-run
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            echo "verify=false" >> "$GITHUB_OUTPUT"
+          else
+            uv run --frozen ai-daily run --date "$TARGET_DATE" --mode publish
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            echo "verify=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Upload audit artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ai-daily-${{ steps.target.outputs.date }}-${{ github.run_id }}
+          path: artifacts/
+          if-no-files-found: ignore
+          retention-days: 90
+
+  deploy:
+    needs: prepare
+    if: needs.prepare.outputs.deploy == 'true'
+    uses: ./.github/workflows/generate_site.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      issues: read
+      pages: write
+      id-token: write
+
+  verify:
+    needs: [prepare, deploy]
+    if: always() && needs.prepare.result == 'success' && needs.prepare.outputs.verify == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      SITE_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install locked dependencies
+        run: |
+          python -m pip install uv==0.9.28
+          uv sync --frozen --no-dev
+      - name: Verify website and RSS
+        env:
+          TARGET_DATE: ${{ needs.prepare.outputs.target_date }}
+        run: |
+          for attempt in 1 2 3 4 5 6; do
+            if uv run --frozen ai-daily verify --date "$TARGET_DATE"; then
+              exit 0
+            fi
+            sleep 20
+          done
+          exit 1

--- a/.github/workflows/generate_site.yml
+++ b/.github/workflows/generate_site.yml
@@ -1,12 +1,14 @@
 name: Deploy static content to Pages
 
 on:
+  workflow_call:
   push:
     branches:
       - main
     paths:
       - main.py
-      - requirements.txt
+      - pyproject.toml
+      - uv.lock
       - config.toml
       - static/**
       - .github/workflows/generate_site.yml
@@ -61,14 +63,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-          cache: pip
-          cache-dependency-path: "requirements.txt"
       - name: Install Python dependencies
         run: |
-          pip install -r requirements.txt
+          python -m pip install uv==0.9.28
+          uv sync --frozen --no-dev
       - name: Generate markdown and build site
         run: |
-          python main.py ${{ github.token }} ${{ github.repository }}
+          uv run --frozen python main.py ${{ github.token }} ${{ github.repository }}
           gh release download $ISITE_VERSION --repo kemingy/isite -p '*linux_amd64*' --output isite.tar.gz
           tar zxf isite.tar.gz && mv isite /usr/local/bin
           isite generate --user $USER --repo $REPO

--- a/.github/workflows/generate_site.yml
+++ b/.github/workflows/generate_site.yml
@@ -70,7 +70,7 @@ jobs:
           uv sync --frozen --no-dev
       - name: Generate markdown and build site
         run: |
-          uv run --frozen python main.py ${{ github.token }} ${{ github.repository }}
+          uv run --frozen python main.py ${{ github.repository }}
           gh release download $ISITE_VERSION --repo kemingy/isite -p '*linux_amd64*' --output isite.tar.gz
           tar zxf isite.tar.gz && mv isite /usr/local/bin
           isite generate --user $USER --repo $REPO

--- a/.github/workflows/generate_site.yml
+++ b/.github/workflows/generate_site.yml
@@ -55,7 +55,8 @@ jobs:
       ZOLA_VERSION: v0.20.0
       USER: ${{ github.repository_owner }}
       REPO: ${{ github.event.repository.name }}
-      BASE_URL: https://wjy9902.github.io/ai-daily
+      BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+      SITE_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,13 @@ output/
 __pycache__/
 *.pyc
 .DS_Store
+.venv/
+.env
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.ai-daily/
+artifacts/
+*.tar.gz
+isite
+zola

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@
 - GitHub Actions 自动构建部署
 - GitHub Pages 托管
 
+## 自动生成器
+
+新的生成流水线位于 `src/ai_daily`，仅采集公开网站、RSS 和官方 API。模型密钥只从环境变量读取，不写入仓库。
+
+```bash
+uv sync --frozen --all-groups
+uv run ai-daily run --date 2026-08-12 --mode dry-run
+uv run ai-daily benchmark-models --dataset tests/evals
+```
+
+生产运行、密钥配置、故障恢复和回滚说明见 [`docs/OPERATIONS.md`](docs/OPERATIONS.md)。完整实施设计见 [`docs/plan/PLAN.md`](docs/plan/PLAN.md)。
+
 ---
 
 Powered by 🍗 鸡胸肉

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -1,0 +1,41 @@
+budget:
+  request_limit: 30
+  input_token_limit: 200000
+  output_token_limit: 30000
+  cost_cny_limit: 5.0
+
+roles:
+  judge:
+    primary:
+      provider: alibaba
+      model: qwen3.7-flash
+      timeout_seconds: 45
+      max_output_tokens: 4096
+      temperature: 0.1
+      input_cost_cny_per_million: 0.7
+      output_cost_cny_per_million: 2.0
+    fallback:
+      provider: deepseek
+      model: deepseek-v4-flash
+      timeout_seconds: 60
+      max_output_tokens: 4096
+      temperature: 0.1
+      input_cost_cny_per_million: 1.01
+      output_cost_cny_per_million: 2.02
+  editor:
+    primary:
+      provider: alibaba
+      model: qwen3.8-max
+      timeout_seconds: 90
+      max_output_tokens: 8192
+      temperature: 0.2
+      input_cost_cny_per_million: 2.5
+      output_cost_cny_per_million: 10.0
+    fallback:
+      provider: deepseek
+      model: deepseek-v4-pro
+      timeout_seconds: 120
+      max_output_tokens: 8192
+      temperature: 0.2
+      input_cost_cny_per_million: 3.13
+      output_cost_cny_per_million: 6.26

--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -1,0 +1,11 @@
+timezone: Asia/Shanghai
+site_base_url: https://wjy9902.github.io/ai-daily
+repository: wjy9902/ai-daily
+artifacts_dir: artifacts
+candidate_limit: 60
+selected_min: 8
+selected_max: 12
+tier_a_min_coverage: 0.6
+collection_window_hours: 36
+cluster_window_hours: 48
+history_window_days: 45

--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -1,0 +1,37 @@
+sources:
+  - name: openai-news
+    kind: rss
+    url: https://openai.com/news/rss.xml
+    tier: A
+  - name: google-ai
+    kind: rss
+    url: https://blog.google/technology/ai/rss/
+    tier: A
+  - name: deepmind
+    kind: rss
+    url: https://deepmind.google/blog/rss.xml
+    tier: A
+  - name: huggingface-blog
+    kind: rss
+    url: https://huggingface.co/blog/feed.xml
+    tier: A
+  - name: hacker-news
+    kind: hackernews
+    url: https://hacker-news.firebaseio.com/v0
+    tier: B
+    limit: 30
+  - name: arxiv-ai
+    kind: arxiv
+    url: https://export.arxiv.org/api/query
+    tier: B
+    limit: 30
+  - name: huggingface-papers
+    kind: huggingface
+    url: https://huggingface.co/api/daily_papers
+    tier: B
+    limit: 20
+  - name: pydantic-ai-releases
+    kind: github_releases
+    url: https://api.github.com/repos/pydantic/pydantic-ai/releases
+    tier: B
+    limit: 10

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,62 @@
+# AI Daily 运维手册
+
+## 安全前提
+
+本项目只读取 `DASHSCOPE_API_KEY`、`DASHSCOPE_BASE_URL`、`DEEPSEEK_API_KEY`、`GITHUB_TOKEN`。密钥只能进入本机环境变量或 GitHub Actions Secrets，禁止写入 `.env.example`、YAML、测试 fixture、日志和 artifact。
+
+对话中曾暴露的密钥必须先在两个供应商控制台吊销；之后生成的新密钥不要粘贴到聊天、Issue 或终端历史中。百炼正式环境使用华北 2 业务空间专属兼容地址。
+
+## 本地验证
+
+```bash
+uv sync --all-groups
+uv run ruff check .
+uv run mypy src
+uv run pyright
+uv run pytest
+uv run ai-daily run --date 2026-08-12 --mode dry-run
+```
+
+最后一条命令会调用云模型，但不会发布。无新密钥时只运行前三类离线检查，以及 `Collector` 的公开来源 smoke。
+
+四模型评测：
+
+```bash
+uv run ai-daily benchmark-models --dataset tests/evals/judge-golden.json
+```
+
+评测会真实调用四个配置模型。所有 20 条必须通过 schema 和证据 ID 门禁；出现 fallback 的候选不具备晋级资格。第一名至少领先第二名 5 分才建议修改 `config/models.yaml`。
+
+## GitHub 配置
+
+仓库 Secrets：
+
+- `DASHSCOPE_API_KEY`
+- `DASHSCOPE_BASE_URL`
+- `DEEPSEEK_API_KEY`
+
+`GITHUB_TOKEN` 使用 Actions 自动提供的短期 token。日报 job 只有 `contents: read` 与 `issues: write`；Pages 权限隔离在可复用站点工作流。
+
+首次启用前，先在 staging 仓库通过 `workflow_dispatch` 选择 `dry-run`，再选择 `publish`。确认同一日期重复运行仍只有一个带 `Daily` 标签的 Issue，且页面和 RSS 最新条目一致。
+
+## 正式调度
+
+- 04:20 Asia/Shanghai：完整生成、发布、构建和验证。
+- 05:05：若当日页面已验证则退出，否则幂等恢复。
+- 05:45：只验证；失败时重建站点，不调用模型。
+- 三段任务共享 `ai-daily-publication-lock`，禁止并发写入。
+
+## 失败处理
+
+| 现象 | 自动行为 | 人工检查 |
+|---|---|---|
+| 单个普通来源失败 | 记录健康状态并继续 | 检查来源是否永久迁移 |
+| Tier A 覆盖低于 60% | 停止发布 | 网络、解析器、来源变更 |
+| 429、连接失败、可恢复 5xx | 按显式跨 Provider 链切换 | 配额和供应商状态页 |
+| 401/403、schema、参数错误 | 立即失败，不切模型 | Secret、模型名、配置版本 |
+| Issue 已存在、站点未更新 | 只重建 Pages | Pages job 与 isite/Zola 日志 |
+| 06:00 后仍不可见 | Actions 标红 | 若 30 天出现两次 runner 排队，迁移 runner |
+
+## 回滚
+
+先在 Actions 中禁用 `Generate AI Daily` schedule，保留 `generate_site.yml`。回滚代码只恢复上一版 workflow 和生成器，不删除历史 Issue、Pages 或 RSS。任何提交、推送、Secret 创建和正式启用都需要用户明确授权。

--- a/docs/plan/PLAN.md
+++ b/docs/plan/PLAN.md
@@ -1,0 +1,724 @@
+# Plan
+
+构建一个独立、可审计、低运维的“甲鱼 AI 日报”流水线：以官方 RSS/API 为主采集来源，完成来源健康检查、规范化、跨源事件聚类、受证据约束的编辑和幂等发布；保留现有 GitHub Issues → GitHub Pages/RSS 发布层，不恢复 OpenClaw、RagFlow 或通用 Agent 平台。
+
+> 状态：规划完成，尚未开始实现。
+> 项目目录：`/Users/jessew/projects/ai-daily`
+> 采集项目调研：[research/collection-methods.md](research/collection-methods.md)
+> 多云模型调研：[research/model-provider-layer.md](research/model-provider-layer.md)
+
+## 1. 成功标准
+
+新系统成功，不是“每天能生成一篇文字”，而是同时满足以下条件：
+
+- 每条入选信息都能追溯到明确来源，来源失败不会被伪装成空结果。
+- 同一事件的多家报道被合并，而不是在日报里重复出现。
+- 重要事实、数字和版本号有原始链接支撑；深度条目必须有第一方证据。
+- 同一天重复运行只更新同一份日报，不生成重复 Issue。
+- 不依赖某台 Mac 上的绝对路径、OpenClaw 会话、浏览器 Cookie、代理或常驻容器。
+- 一次来源故障不会拖垮整份日报；系统性故障又会明确失败，不能发布一份看似正常的残缺日报。
+- 本地可以 dry-run，GitHub Actions 可以定时运行，运行产物足以复盘“收到了什么、为什么选这些”。
+- 每天北京时间 06:00 前，当日日报已经能从网站打开，并出现在 RSS 的最新条目中。
+- 正式流程从采集到发布全自动完成，不等待人工审核；质量门禁失败时自动恢复或明确失败，不把人工确认变成日常依赖。
+- 唯一公开渠道是网站和 RSS，不维护 Telegram、微信、邮件或其他推送分支。
+
+## 2. 已确定的设计决策
+
+### 2.1 系统边界
+
+1. **不使用 OpenClaw 作为运行时。** Prompt 只负责有限的内容判断和写作，不负责调度、抓取和发布控制。
+2. **不恢复 RagFlow、Redis、向量数据库或浏览器自动化集群。** 日报首版不需要 RAG 平台。
+3. **采用可切换的进程内模型层。** 使用 `pydantic-ai-slim` 的 typed model/provider 能力，通过 `provider:model` 配置切换直连云模型、OpenRouter 或本机 Ollama；不运行独立模型网关。Ollama 不会在生产故障时静默接管。
+4. **保留现有发布仓库和历史。** `/Users/jessew/projects/ai-daily` 后续应成为现有 [wjy9902/ai-daily](https://github.com/wjy9902/ai-daily) 的正式本地工作目录，在同一仓库中加入生成器，避免新建第二个远程仓库和跨仓库 Token。
+5. **先做单次完整采集 + 截止前恢复。** 04:20 执行完整流水线，05:05 只在当日结果缺失或未验证时做幂等恢复，05:45 做轻量最终校验/站点重建；不恢复旧系统的跨运行原始候选池。
+6. **首版没有后台 UI。** 来源由版本化配置文件管理，运行状态由 CLI、测试、GitHub Actions Summary 和审计产物查看。
+7. **渠道固定为网站和 RSS。** 不恢复 Telegram，也不把微信、邮件或其他通知列入首版后续事项。
+8. **生产发布完全自动。** 不创建待人工确认的草稿；实现阶段先在测试仓库完成端到端验证，启用正式调度后由自动质量门禁决定发布或失败。
+
+### 2.2 技术选型
+
+- Python 3.12；依赖和命令由 `uv` 管理。
+- `httpx` 负责异步 HTTP；`feedparser` 解析 RSS/Atom；Pydantic 负责配置和模型校验。
+- SQLite 只作为一次运行内的事务性工作库；不把二进制数据库提交到 Git。
+- shortlist 正文抽取优先评估 `trafilatura`，只对少量候选执行；不默认启用浏览器。
+- 模型调用使用 `pydantic-ai-slim` 和严格 Pydantic output type，只安装实际使用的 provider extras；项目内保留一个小型 `ModelGateway` 边界，不使用工具、MCP、图、Web UI、Logfire 或多 Agent。
+- `config/models.yaml` 分别声明 `judge` 与 `editor` 的 primary、显式跨 provider fallback、timeout 和预算；API key 仅来自环境变量/Secrets。
+- 测试使用 `pytest`、固定 fixtures 和 HTTP mock；代码质量使用 Ruff 和类型检查。
+- 发布使用 GitHub REST API；站点继续使用当前 PyGithub/isite/Zola/GitHub Pages 链路，第一阶段只做必要的信任规则与可复用工作流改造。
+
+具体依赖必须在实现阶段按“仓库搜索 → 成熟包 → 现有模式 → 才自行实现”的顺序确认，计划中的包名不是提前锁死的依赖清单。
+
+### 2.3 模型 Provider 与切换策略
+
+调研比较了 Pydantic AI、Instructor、LiteLLM、aisuite、OpenRouter、Portkey 和 BAML。最终选择 `pydantic-ai-slim`，原因是它同时提供主流 provider、Pydantic 结构化输出、model capability profile、测试模型、用量限制和显式 `FallbackModel`，又可以只安装需要的 extras，不必部署 proxy/Redis/控制台。详细证据见[多云模型调研](research/model-provider-layer.md)。
+
+配置按任务角色而不是在代码里写死模型名：
+
+```yaml
+profiles:
+  judge:
+    primary: "<provider>:<model>"
+    fallbacks: ["<different-provider>:<model>"]
+    timeout_seconds: 90
+    output_retries: 1
+  editor:
+    primary: "<provider>:<model>"
+    fallbacks: ["<different-provider>:<model>"]
+    timeout_seconds: 120
+    output_retries: 1
+```
+
+执行规则：
+
+- provider/model 切换只修改配置和 Secrets，再运行 capability check、固定评测集及 live smoke，不修改采集/编辑业务代码；
+- 只在 timeout、连接失败、429 和可恢复 5xx 时进入显式配置的下一家 provider；认证、参数、上下文和 schema 配置错误立即失败；
+- 输出校验失败在同一模型内重试一次，仍失败则该阶段失败，不把未验证内容交给另一个模型掩盖；
+- 每次调用记录 profile、请求/实际 provider 与 model、fallback 原因、延迟、tokens 和可获得的成本数据；fallback 不得静默；
+- Ollama 只作为本机明确选择的 profile；生产 fallback 必须是另一家云 provider；
+- OpenRouter 可以是一个可选 provider，但需固定 model slug，并设置 `require_parameters=true`、`allow_fallbacks=false`、`data_collection=deny`，让故障链仍由本项目控制；
+- LiteLLM/Portkey 只有在至少三个应用需要共享密钥、预算和路由时才重新评估，首版不部署模型网关。
+
+初始 `judge`/`editor` 不在计划里硬编码易过期的模型名。实现时用最近 20–30 期旧日报构建评测集，对至少两家独立云 provider 按证据忠实度 35%、选题质量 20%、结构化输出 15%、中文编辑 15%、延迟稳定性 10%、成本 5% 评分，再把胜出者写入配置。
+
+## 3. Scope
+
+### 3.1 包含
+
+- 声明式来源注册表和严格配置校验；
+- RSS/Atom、JSON/REST API、少量官方 HTML change-watch 三类 adapter；
+- 异步并发、超时、有限重试、按 host 限流和条件 HTTP；
+- 标准数据模型、来源血缘、运行健康状态和审计产物；
+- URL 规范化、精确去重、标题近似去重和同事件聚类；
+- shortlist 后正文抽取与证据包；
+- 确定性初筛、结构化模型判断、日报选题和中文编辑；
+- 可配置的多云模型 profile、显式 fallback、模型用量/实际路由审计；
+- Markdown/链接/证据/日期/重复项验证；
+- 当日 GitHub Issue 幂等创建或更新；
+- 现有 Pages/RSS 构建的显式触发和发布后验证；
+- 本地 dry-run、历史日期 backfill 和 GitHub Actions 定时运行；
+- 单元、契约、集成、端到端、幂等与故障测试。
+
+### 3.2 不包含
+
+- OpenClaw、RagFlow、Redis、消息队列、向量数据库；
+- Telegram、微信公众号、邮件和其他内容发布/推送渠道；
+- X、Reddit、微信公众号 Cookie 抓取或登录浏览器；
+- 通用 web search 作为定时主来源；
+- 全网爬虫、永久全文归档、付费墙绕过；
+- 后台管理界面、多人权限、插件市场、MCP Server；
+- 投资/交易型宏观日报；
+- 首版的小时级实时雷达。
+
+除“只保留网站和 RSS”这一已确定的渠道边界外，其他排除项若未来出现明确需求，必须作为独立变更重新评估，不能顺手塞回核心流水线。
+
+## 4. 目标架构
+
+```mermaid
+flowchart LR
+    A["来源注册表\nTier / host / parser / policy"] --> B["并发 Adapters\nRSS / API / Change Watch"]
+    B --> C["运行工作库\nitems + source runs + provenance"]
+    C --> D["规范化\nURL / 时间 / 作者 / 指标"]
+    D --> E["精确去重与事件聚类"]
+    E --> F["确定性初筛与分类配额"]
+    F --> G["Shortlist 正文抽取"]
+    G --> P["ModelGateway\njudge / editor profiles"]
+    P --> H["结构化 AI 判断与逐条写作"]
+    H --> I["内容验证与质量门禁"]
+    I --> J["幂等发布 GitHub Issue"]
+    J --> K["现有 isite + Zola"]
+    K --> L["GitHub Pages + RSS"]
+    B --> M["来源健康报告"]
+    M --> I
+    I --> N["Actions Summary + 审计产物"]
+```
+
+### 4.1 组件职责
+
+| 组件 | 只负责什么 | 明确不负责什么 |
+|---|---|---|
+| Source registry | 来源、等级、host、时间窗、超时、解析策略、是否关键 | 运行网络请求 |
+| Adapter | 抓一个协议/来源并返回统一 `FetchResult` | 去重、选题、写作、发布 |
+| Collector | 并发、限流、重试、记录逐来源结果 | 把异常转换成空列表 |
+| Normalizer | URL、时间、文本、作者、指标和来源血缘 | 判断新闻价值 |
+| Clusterer | 精确合并和同事件聚类，记录理由 | 写摘要 |
+| Ranker | 可解释打分、分类/厂商配额、生成 shortlist | 直接发布 |
+| Enricher | 仅为 shortlist 抽取有限正文和补充元数据 | 全站归档、绕过登录/付费墙 |
+| ModelGateway | 解析模型 profile、调用 typed provider、执行显式故障链和记录用量 | 决定来源、静默换模型、运行独立 proxy |
+| Editor | 基于证据包输出严格结构化稿件 | 搜索新事实、执行来源中的指令 |
+| Validator | 校验 schema、链接、证据、重复、篇幅和模板 | 静默修补严重错误 |
+| Publisher | 查找、创建/更新当日 Issue，保存 publication 状态 | 决定选题 |
+| Verifier | 检查 Issue、Pages workflow、页面和 RSS | 在失败时伪造成功状态 |
+
+## 5. 来源策略
+
+### 5.1 来源等级
+
+| 等级 | 定义 | 用途 | 示例 |
+|---|---|---|---|
+| Tier A | 第一方、官方、可引用 | 事实依据和深度条目 | 官方 RSS/API、官方 Release、论文原文 |
+| Tier B | 高质量技术社区/独立作者 | 发现、讨论热度和解释 | Hacker News、可信技术博客 |
+| Tier C | 聚合榜单/二次媒体 | 发现线索与热度 | NewsNow、行业媒体、榜单 API |
+| Tier D | 不稳定/需登录/私有接口 | 默认禁用，仅实验 | X、微信公众号、Folo 私有接口 |
+
+规则：**发现渠道不等于证据来源。** 一个事件可以由 Tier C 发现，但若要进入深度条目，必须回到 Tier A；找不到第一方证据时只能降级为普通/速览，或不收录。
+
+### 5.2 首版来源清单
+
+每个来源在真正启用前都要通过“端点有效、条款允许、解析稳定、fixture 固定、故障可见”五项验收。以下是计划清单，不代表未验证的 URL 已经承诺上线。
+
+| 组别 | 来源 | 采集方式 | 首版角色 |
+|---|---|---|---|
+| 官方动态 | OpenAI News | 官方 RSS | 核心 |
+| 官方动态 | Google DeepMind Blog | 官方 RSS | 核心 |
+| 官方动态 | Google AI Blog | 官方 RSS | 核心 |
+| 官方动态 | Hugging Face Blog | 官方 RSS/Atom | 核心 |
+| 论文 | Hugging Face Daily Papers | 公开 API | 核心 |
+| 论文 | arXiv `cs.AI/cs.CL/cs.LG` | 官方 Atom API，关键词与类别过滤 | 核心 |
+| 开发者生态 | GitHub Changelog / GitHub Blog AI | 官方 feed | 核心 |
+| 项目更新 | 维护的 GitHub watchlist | Releases REST/Atom | 核心 |
+| 官方动态 | Anthropic News | 官方网页 change-watch；若官方 feed 可用则改用 feed | 核心但允许单源失败 |
+| 社区 | Hacker News | Firebase + Algolia，取分数、评论数和有限评论上下文 | 信号 |
+| 独立分析 | Simon Willison、Latent Space 等 3–5 个精选 feed | RSS/Atom | 信号/解释 |
+| 国内官方 | 2–4 家中国模型厂商的官方发布页 | 官方 feed/API 优先，否则受限 change-watch | 首版逐一验收 |
+
+### 5.3 第二阶段候选
+
+- OSS Insight star gain 或 GitHub Search：只做开源项目热度，不抓 GitHub Trending HTML。
+- NewsNow/TrendRadar：只输入热榜排名和轨迹，不直接成为事实证据。
+- YouTube 官方 channel Atom feed：仅跟踪白名单官方频道，不用 yt-dlp 做全站搜索。
+- Bilibili 公开热门/API：只做国内热度信号，遇到风控即标记 blocked。
+- RSSHub：只有不可替代且持续稳定的路由才接入。
+- changedetection.io：当轻量 change-watch 规则超过维护阈值时作为独立旁路服务。
+
+### 5.4 首版明确禁用
+
+- X/Twitter：官方 API 成本和第三方桥接稳定性不足；
+- Reddit：公开端点限流/403 历史较多，且不是本日报不可替代来源；
+- 微信公众号：没有稳定的公开批量协议，Cookie/浏览器路径维护和合规成本高；
+- Product Hunt：在没有稳定、授权 API 方案前不抓 HTML；
+- 通用搜索 API：只允许人工调研或一次性来源发现，不进入定时主链路；
+- Folo、SocialData、TikHub 等内部/付费桥接：没有单独预算和风险决定前不接入。
+
+## 6. Adapter 与失败契约
+
+每个 adapter 返回同一种结果，而不是“成功返回数组、失败也返回空数组”。概念契约如下：
+
+```text
+fetch(source, context) -> FetchResult
+
+FetchResult:
+  source_id
+  status
+  started_at / finished_at
+  http_status
+  item_count
+  etag / last_modified
+  retry_count
+  items[]
+  error_code / error_message
+```
+
+`status` 必须是以下枚举之一：
+
+- `success`：请求和解析成功且有条目；
+- `success_empty`：成功，但时间窗内确实没有条目；
+- `not_modified`：条件请求确认无变化；
+- `failed_fetch`：DNS、连接、超时、TLS 或非预期 HTTP；
+- `failed_parse`：响应成功但内容不符合 schema；
+- `rate_limited`：明确的 429/限额；
+- `blocked`：风控、登录或条款阻断；
+- `disabled`：配置中禁用。
+
+实现规则：
+
+- Adapter 只捕获已知网络/解析异常并转换为带类型的 source error；未知异常向上抛出并让该来源失败。
+- 默认连接/读取超时分别配置，单源总时限不超过 20 秒；最多两次带 jitter 的指数退避，并尊重 `Retry-After`。
+- 同一 host 有并发上限；RSS/API 支持 ETag/Last-Modified 时发条件请求。
+- 注册表是静态 allowlist，只允许 HTTPS；重定向后的 host 也必须通过校验，防止 SSRF。
+- 日志不输出 Authorization、Cookie、URL credentials、模型密钥或完整原文。
+- 所有来源文本都视为不可信数据，不能作为系统指令，也不能触发代码、工具或 shell。
+
+## 7. 数据模型与审计产物
+
+### 7.1 核心实体
+
+| 实体 | 关键字段 | 目的 |
+|---|---|---|
+| `SourceDefinition` | id、kind、tier、region、URL/host、critical、timeout、parser、policy | 来源的版本化声明 |
+| `SourceRun` | run_id、source_id、status、时间、HTTP 状态、重试、数量、错误 | 区分空、失败和降级 |
+| `RawItem` | source item ID、URL、标题、摘要、发布时间、发现时间、作者、指标、来源 | 保留入站血缘 |
+| `NormalizedItem` | canonical URL、规范时间、清洗文本、content hash、语言 | 稳定比较 |
+| `EventCluster` | event ID、规范标题、primary item、members、cluster reason/confidence | 合并同一事件 |
+| `EvidenceBundle` | 事件、第一方链接、辅助链接、有限摘录、提取状态 | 约束模型写作 |
+| `ModelRun` | profile、requested/actual provider/model、attempt、fallback reason、usage、cost、latency、status | 支持模型切换与故障审计 |
+| `DigestItem` | event ID、rank、level、category、tags、score breakdown、正文 | 日报条目 |
+| `Publication` | date、issue number、digest hash、status、attempts、verified_at | 幂等与验证 |
+
+### 7.2 每次运行的文件
+
+```text
+var/runs/YYYY-MM-DD/<run-id>/
+  manifest.json
+  source-runs.json
+  raw-items.jsonl
+  normalized-items.jsonl
+  event-clusters.jsonl
+  selection.json
+  model-runs.json
+  digest.md
+  validation.json
+  health.json
+  run.sqlite
+```
+
+- `var/` 默认 Git ignore，本地保留用于调试。
+- GitHub Actions 上传经过脱敏的 JSON/Markdown 产物，建议 `retention-days: 90`；不上传密钥、Cookie、完整网页或付费内容。
+- 完整正文只存在于运行期 SQLite/临时目录；审计产物保存有限证据摘录、URL、hash 和抽取状态。
+- 发布后的长期去重不依赖 Actions artifact，而是读取最近 45 天日报 Issue 中的机器标记和来源 URL。因此 artifact 丢失不会改变发布正确性；若读取历史失败则明确终止去重阶段，不静默忽略。
+
+## 8. 规范化、去重与事件聚类
+
+### 8.1 URL 规范化
+
+- host 小写、删除 fragment、标准化默认端口；
+- 删除 `utm_*`、`fbclid`、`gclid` 等跟踪参数；
+- 对已知域名执行可测试的 canonical 规则，不写通用猜测；
+- 只在 host allowlist 内跟随重定向；
+- 同时保留原 URL 和 canonical URL，不能丢失血缘。
+
+### 8.2 三阶段合并
+
+1. **精确层**：canonical URL、官方对象 ID、论文 ID、GitHub repo+release tag 完全相同。
+2. **确定性近似层**：在 48 小时窗内比较规范标题、关键实体、厂商、模型名和版本；只有高阈值且实体不冲突才合并。
+3. **歧义裁决层**：仅把边界候选交给模型，模型返回 `same_event / different_event / uncertain`、置信度和理由；`uncertain` 默认不合并。
+
+每次合并都要保存成员、主来源和理由。禁止仅凭“标题都提到 GPT”就合并，也不能把模型不同版本、论文修订和产品更新错误折叠。
+
+### 8.3 跨日报去重
+
+- 每个 Event 生成稳定 `event_id`；日报 Markdown 在每条下写隐藏 marker。
+- 发布前读取最近 45 天 Issue 的 `event_id` 和 canonical URL。
+- 同一事件默认 14 天内不重复；若确有重大后续，使用 `follow_up_of` 明确关联，并在标题中说明“更新”。
+- 论文/项目的版本发布按版本 ID 区分，不因 repo/论文主 URL 相同就全部过滤。
+
+## 9. 筛选、全文与编辑策略
+
+### 9.1 内容定位与优先顺序
+
+日报面向“既关心 AI 技术变化，又需要把信息转化为产品、工程或业务行动”的中文读者。它不是论文榜、融资简报或全网热搜合集，核心判断顺序是：
+
+1. **今天能否改变判断或行动**：新能力、成本变化、可直接使用的工具和生态迁移优先；
+2. **是否有可信的一手证据**：官方发布、代码/Release、论文原文优先于二次解读；
+3. **是否真正新增**：旧闻改标题、营销合集、无新信息的跟风讨论不收；
+4. **是否覆盖中外关键变化**：国内信息必须有稳定官方来源，不为“国内栏目”硬凑条目。
+
+每天 8–12 条的软配额：
+
+| 内容类型 | 目标数量 | 选择标准 |
+|---|---:|---|
+| 模型、平台和官方能力更新 | 2–3 | 能力、价格、API、许可或可用性发生实质变化 |
+| 开发者工具与开源项目 | 2–3 | 可实际试用，有代码/Release/文档，不只看 Star |
+| 重要研究 | 1–2 | 方法或结果对模型/产品有明确意义，不做论文堆砌 |
+| 国内 AI 与重大行业变化 | 1–2 | 影响产品、成本、监管或竞争格局，有可靠证据 |
+| 其他速览 | 0–2 | 有价值但不需要长篇分析 |
+
+“产品机会”和“今日行动项”由当天入选事件推导，不另外抓一批低质量创业资讯。融资、人事、传闻和泛政策只在确实改变行业格局且证据充分时收录；没有合格内容的类型可以为零。
+
+### 9.2 确定性初筛
+
+模型调用前先完成：
+
+- 时间窗、语言、来源等级、AI 相关关键词/排除词；
+- 官方来源保底与单来源上限；
+- 垃圾标题、活动广告、职位、重复周报和纯营销过滤；
+- 事件聚类；
+- 可解释初始分数。
+
+初始 100 分建议权重：
+
+| 维度 | 权重 | 说明 |
+|---|---:|---|
+| AI 相关性 | 20 | 与模型、工具、研究、开发者生态或产业变化的直接程度 |
+| 证据质量 | 20 | 第一方/原文、来源等级、信息完整性 |
+| 技术或产品影响 | 20 | 能否改变能力、成本、工作流或市场格局 |
+| 实用价值 | 15 | 读者今天是否能使用、验证或做决定 |
+| 新颖性与时效 | 15 | 是否真正新增、是否处于有效时间窗 |
+| 多源佐证与热度 | 10 | 独立来源、讨论/排名信号；不把重复转载当佐证 |
+
+厂商过度集中、同主题过量、纯二手信息和证据缺失使用显式 penalty，不暗改原始分数。
+
+### 9.3 Shortlist 后再抓正文
+
+- 初筛后只保留约 20–30 个事件进入 enrichment。
+- 优先使用 feed/API 自带内容；确有必要才请求原始网页并用轻量正文抽取。
+- 不登录、不绕付费墙、不执行页面 JavaScript、不下载无关资产。
+- 正文抽取失败与“feed 摘要可用”分别记录；快速条目可使用可靠摘要，深度条目必须有足够正文或结构化第一方数据。
+- 模型只收到与当前事件有关的有限证据包，降低成本和 Prompt injection 面。
+
+### 9.4 模型职责
+
+模型分两步使用，不让一个长 Prompt 一次包办整份日报：
+
+1. **结构化评审**：为每个 Event 返回相关性、影响、建议级别、分类、标签、推荐理由、风险和应引用来源；输出必须通过 schema。
+2. **逐条写作**：只基于该 Event 的 EvidenceBundle 写中文条目；没有证据的数字、比较和因果关系不得生成。
+
+最后由确定性 assembler 组合栏目、目录、来源链接和编辑观察。编辑观察可以由模型起草，但必须只引用已选 Event。
+
+模型失败时：
+
+- API/网络/限流类故障只按 `models.yaml` 中的显式跨 provider 顺序切换，并记录实际模型和原因；
+- 认证、参数、schema、上下文和输出质量错误不通过换模型掩盖；
+- Ollama 不自动接管生产任务；
+- 不把候选标题直接拼成“正常日报”；
+- 保留候选和健康产物，任务明确失败；
+- 05:05 恢复任务可用同一 run-id 重跑 compose；本地也可手工重跑，但正式发布不等待人工批准。
+
+### 9.5 日报产品规则
+
+- 通常 8–12 条；安静日可以少于 8 条，绝不为了凑数降低门槛。
+- 2–3 条深度、4–5 条标准、2–4 条速览只是目标分布，不是硬凑配额。
+- 栏目保留：模型与平台、前沿研究、值得试的项目、行业动态、国内 AI 动态、产品机会、今日行动项；当天无合格内容的栏目可以省略。
+- 同一厂商默认不超过 2 条，除非当日确有多个独立重大事件，并在选择报告中解释。
+- 每条至少一个可点击原始来源；深度条目至少一个 Tier A，重要争议最好有第二个独立来源。
+- 正文以转述和分析为主，不长篇复制来源；保留现有“AI 辅助、以原始信息为准”的声明。
+
+## 10. 质量门禁与故障策略
+
+### 10.1 发布前门禁
+
+以下条件全部满足才允许正常发布：
+
+- 配置和所有结构化产物通过 schema；
+- 至少 60% 的启用 Tier A 来源成功或 `not_modified`，且不存在共同网络/解析系统性故障；阈值先用历史回放和测试仓库 canary 校准，上线后按数据显式调整；
+- 每个入选 Event 有 canonical URL、来源血缘、发布时间或明确的发现时间；
+- 所有深度条目有 Tier A 证据；
+- 没有重复 event ID、重复 canonical URL、空链接、模板占位符或未闭合 Markdown；
+- 文内事实检查结果无 blocker；
+- 模型、发布 API 和验证阶段都返回明确成功；
+- 每次模型调用都有实际 provider/model 记录；发生 fallback 时仍通过相同 schema 和事实门禁；
+- 当天 Issue 的目标状态可判定，不能出现“不知道是否创建成功就再创建一次”。
+
+如果来源健康但当天只有少量真正重要事件，允许发布“短版”。如果来源健康门禁未通过，则不发布伪正常日报；Actions 失败并保留 health report。
+
+### 10.2 部分失败
+
+- 非关键来源失败：继续，但在 health report 中保留错误；若影响明显，在日报末尾加简短“采集说明”。
+- 一个关键来源失败：是否发布由整体 Tier A 覆盖率决定，不做隐式替换。
+- 多个来源同类失败：视为系统性问题，停止发布。
+- 429：尊重 `Retry-After`，本次超时后标记 rate-limited，不用代理绕过。
+- HTML 规则失效：标记 failed-parse，不能把整页导航文本当内容。
+- 发布后页面/RSS 验证失败：Issue 不重复创建，publication 标记为 `issue_published_site_unverified`，重试部署/验证。
+
+## 11. 发布与幂等设计
+
+### 11.1 当日 Issue 身份
+
+- 标题固定为 `甲鱼 AI 日报 · YYYY-MM-DD`。
+- 使用标签 `daily` 和 `generated`。
+- body 顶部加入机器 marker，例如：
+
+```html
+<!-- ai-daily:v2 date=2026-08-12 digest_sha256=<hash> run_id=<id> -->
+```
+
+- 每个条目加入独立 `event_id` marker，供跨日去重和审计。
+
+### 11.2 发布算法
+
+1. 按 marker、日期和标签查询当天 Issue。
+2. 没有时创建；只有一个且作者/marker 可信时更新；出现多个或身份不明时立即失败并要求人工处理。
+3. digest hash 相同则不改 body，只进入验证。
+4. 更新前保存原 issue number/hash 到 publication 记录。
+5. API 请求超时后先重新查询远端状态，再决定是否重试，避免 at-least-once 导致重复 Issue。
+
+### 11.3 与现有站点的兼容
+
+现有 `main.py` 只接受仓库 owner 创建的 Issue；GitHub Actions 使用 `GITHUB_TOKEN` 创建时作者会是 bot。需要做一个小而明确的改造：
+
+- 历史 owner Issue 继续被接受；
+- 新 bot Issue 只有同时具有 `daily` 标签和合法 `ai-daily:v2` marker 时才被接受；
+- 其他用户或无 marker 的 bot 内容仍被忽略。
+
+另外，`GITHUB_TOKEN` 创建的 Issue 通常不会再次触发新的 workflow run。避免使用个人 PAT 的方案是：
+
+- 把站点构建 workflow 抽成可 `workflow_call` 的复用 job；
+- 日报 workflow 发布 Issue 后直接调用站点构建；
+- 手工编辑 Issue 仍保留现有 `issues` 触发器；
+- 发布 workflow 使用最小权限：`contents: read`、`issues: write`、站点 job 所需的 `pages/id-token` 权限分开配置。
+
+### 11.4 发布后验证
+
+- GitHub Issue 可读、标题/marker/hash 正确；
+- Pages deploy job 成功；
+- 当日页面返回 200，并包含当日标题和至少一个 event marker 对应内容；
+- `rss.xml` 返回 200，最新 item 指向当日页面；
+- 验证结果写入 `publication` 和 Actions Summary。
+
+## 12. 调度方案
+
+### 12.1 首版
+
+- **可见性 SLO：每天 06:00 Asia/Shanghai 前，当日网页返回 200，RSS 最新条目指向当日网页。** “Issue 已创建但网页/RSS 未更新”不算达标。
+- 主触发：每天 04:20 Asia/Shanghai（GitHub cron 使用 UTC `20 20 * * *`），执行完整采集、编辑、发布、站点构建和验证，目标 05:00 前结束。
+- 恢复触发：每天 05:05 Asia/Shanghai（UTC `5 21 * * *`）。若网页和 RSS 已验证则立即退出；若 Issue 已存在但站点未更新，只重建并验证站点；若当日 Issue 不存在，则完整幂等重跑，目标 05:40 前结束。
+- 最终校验：每天 05:45 Asia/Shanghai（UTC `45 21 * * *`），只检查 Issue、页面和 RSS；可恢复的站点构建问题自动重建，不重新调用模型。目标 05:55 前结束。
+- 所有触发都从 `Asia/Shanghai` 计算 `target_date`，不能直接使用 UTC 日历日期；三个触发复用同一 workflow/命令和 publication lock，不复制三套逻辑。
+- GitHub hosted runner 的 schedule 可能延迟，因此预留了 100 分钟缓冲。记录 `visible_at_cst`；若滚动 30 天内有 2 次因 runner 排队而晚于 06:00，调度/runner 必须迁移到有明确时间保证的云端执行环境，而不是继续提前 cron 碰运气。
+- 采集窗口默认 `[目标日期前一天 00:00, 运行时刻]` 的约 30–36 小时，并以来源发布时间为主、发现时间为辅。
+- 完整流水线设置 35 分钟总超时，站点恢复设置 10 分钟超时；单日期只允许一个写入型运行，只有持有 publication lock 的任务可以发布。
+- 提供 `workflow_dispatch`：`target_date`、`mode=full|recover|verify`、`dry_run`、`publish`；正式 schedule 固定 `publish=true`，不进入人工审批或草稿状态。
+
+### 12.2 本地命令目标
+
+```text
+uv run ai-daily doctor
+uv run ai-daily collect --date YYYY-MM-DD
+uv run ai-daily compose --run-id <id>
+uv run ai-daily validate --run-id <id>
+uv run ai-daily run --date YYYY-MM-DD --dry-run
+uv run ai-daily publish --run-id <id>
+uv run ai-daily verify --date YYYY-MM-DD
+```
+
+所有写外部状态的命令必须显式使用 `publish` 或 `--publish`；本地默认 dry-run。
+
+### 12.3 何时才增加预采集
+
+上线后的运行数据中，只有出现以下证据才进入第二阶段：
+
+- 每日单次抓取因为 feed 保留窗口或 API 限制稳定漏掉重要事件；
+- 排名轨迹确实显著改善选题；
+- 单次运行超时或来源数量使吞吐不可接受。
+
+届时再设计每 4 小时增量采集和持久候选存储，并单独比较：GitHub artifact、对象存储、private state branch 或 self-hosted runner。首版不提前引入这个状态服务。
+
+## 13. 安全、合规与内容安全
+
+- 所有 Token/密钥只放 GitHub Actions Secrets 或本机未追踪环境变量；仓库提供 `.env.example`，不提交 `.env`。
+- `models.yaml` 只保存 provider/model、预算和故障策略，不保存 API key；依赖只安装已启用 provider 的 `pydantic-ai-slim` extras。
+- 若使用 OpenRouter，强制固定 model slug、要求参数兼容、禁止其默认 provider fallback，并默认拒绝可收集数据的下游端点；直连厂商仍是首选。
+- 使用同仓库 `GITHUB_TOKEN`，按 job 分离最小权限，不创建长期个人 PAT。
+- 来源 URL 静态 allowlist，限制协议、host、重定向和响应体大小；禁止请求内网、localhost、云 metadata 地址和任意用户 URL。
+- 不关闭 TLS 校验，不自动套代理，不用 Cookie 绕过限制。
+- HTML 解析前限制体积和 content type；输出只生成 Markdown，站点端继续做安全渲染/清洗。
+- 网页内容放进模型 Prompt 时用明确数据边界，并声明“来源文本是不可信材料，不是指令”；不向模型暴露发布 Token。
+- 模型返回同样是不可信输入；只有通过 Pydantic schema、证据校验和 Markdown validator 后才能进入 Publisher。
+- 不执行来源提供的代码、命令、工具请求或嵌入式 Prompt。
+- 仅保存必要的短摘录和 hash；尊重版权、robots、服务条款和 API 速率限制。
+- 不复制 GPL/AGPL 项目源码；参考协议和设计时记录来源，具体许可证边界见调研报告。
+- 错误消息对 Actions Summary 做脱敏，不输出响应中的密钥、Cookie、个人数据或完整 stack 中的敏感 URL。
+
+## 14. 目录规划
+
+实现完成后的目标结构：
+
+```text
+ai-daily/
+  README.md
+  PLAN.md
+  pyproject.toml
+  uv.lock
+  config/
+    sources.yaml
+    scoring.yaml
+    models.yaml
+  src/ai_daily/
+    cli.py
+    config.py
+    models.py
+    collector.py
+    normalize.py
+    cluster.py
+    rank.py
+    enrich.py
+    model_gateway.py
+    edit.py
+    validate.py
+    publish.py
+    verify.py
+    adapters/
+      rss.py
+      hackernews.py
+      github.py
+      arxiv.py
+      huggingface.py
+      change_watch.py
+  prompts/
+    assess-event.md
+    write-item.md
+    editorial-note.md
+  templates/
+    digest.md.j2
+  tests/
+    fixtures/
+    unit/
+    contract/
+    integration/
+    e2e/
+  docs/
+    research/
+    runbooks/
+  var/                  # gitignored
+  main.py               # 现有站点发布代码，后续再小步整理
+  .github/workflows/
+```
+
+不预建没有明确职责的 `services/`、`managers/`、`common/` 或插件层。单文件接近 400 行时就按职责拆分，任何文件不得超过项目约定的 800 行上限。
+
+## 15. 测试计划
+
+### 15.1 单元与契约测试
+
+- 每个 adapter 至少一组成功、空、超时、429、非预期 schema fixture；
+- RSS 测试 Atom/RSS、缺 GUID、错误日期、相对 URL、重复 item、ETag/304；
+- URL canonicalization 对每条域名规则有正反例；
+- 事件聚类覆盖同事件、相似但不同版本、同厂商不同产品、跨语言标题；
+- scoring 每一项可解释且总分稳定；
+- model profile 覆盖直连 provider、OpenRouter 可选路径、Ollama 本地路径、API fallback、不可 fallback 配置错误和实际模型审计；
+- 模型 schema 对缺字段、额外字段、非法 URL、unsupported claim 明确失败；
+- Markdown validator 检查链接、marker、重复、模板残留和栏目规则；
+- publisher 覆盖创建、相同 hash 无操作、更新、远端超时后查重、冲突 Issue；
+- verifier 覆盖 Issue 成功但 Pages/RSS 未更新的中间状态。
+
+### 15.2 集成与端到端
+
+- 无网络 E2E：用固定来源 fixtures 生成一份 golden digest；
+- live smoke：只抓少量官方端点，不发布；
+- GitHub 测试 Issue 或专用测试仓库验证幂等，不能在正式日报里试错；
+- 现有站点构建基线测试：历史 Issues、README、30 条 RSS 和 Top/TODO 规则不回归；
+- 一次完整 dry-run 输出 source health、clusters、selection、digest 和 validation；
+- 故障注入：半数来源失败、模型超时、GitHub 500、重复 runner、Pages 延迟。
+- 调度回放：UTC cron 能正确计算北京时间目标日期，04:20 主任务、05:05 恢复和 05:45 校验共享同一 publication，不重复发布。
+
+### 15.3 每次宣称完成前的证据
+
+- `uv run ruff check .` 通过；
+- 类型检查通过；
+- `uv run pytest` 通过；
+- 构建 workflow 在测试环境成功；
+- 同一日期连续执行两次只存在一个目标 Issue；
+- 实际页面和 RSS 验证通过。
+- 在测试仓库的计时 E2E 中，模拟正常运行和一次可恢复故障都能在北京时间 06:00 截止预算内完成。
+
+没有这些新鲜证据时，只能说明已实现但未验证，不能说“完成”或“应该可用”。
+
+## 16. 验收指标
+
+先在测试仓库完成验收；正式启用后自动发布，前 7 天作为增强观察期做发布后抽查，但不设置人工审批门槛。至少记录以下指标：
+
+| 指标 | 首版门槛 |
+|---|---:|
+| 北京时间 06:00 前网页与 RSS 可见 | 100% |
+| 入选条目来源链接覆盖率 | 100% |
+| 深度条目第一方证据覆盖率 | 100% |
+| 同日重复 canonical URL | 0 |
+| 明显同事件重复条目 | 0 |
+| 逐来源运行状态覆盖率 | 100% |
+| 实际 provider/model/fallback 审计覆盖率 | 100% |
+| 发布幂等测试 | 同日两次运行仍为 1 个 Issue |
+| 配置/模型/内容 schema 通过率 | 100% 才发布 |
+| 需要发布后紧急更正的日报 | 首月目标 ≤ 5% |
+| 正式发布人工审批步骤 | 0 |
+
+不能用“条目越多越好”做指标。漏掉一条普通新闻通常比发布一条错误、重复或无来源信息更可接受。
+
+## 17. 实施阶段与退出条件
+
+### Phase 0：接管现有仓库与建立基线（0.5–1 天）
+
+- 把当前目录安全接到现有 `wjy9902/ai-daily` 历史，不覆盖本次文档；
+- 在隔离 worktree 中工作，记录主分支状态；
+- 运行现有 `main.py`/站点 workflow 的本地或等价基线测试；
+- 保存当前网站、RSS 和最新 Issue 的验证结果。
+
+退出条件：历史完整、主分支未被污染、现有发布链路有可重复基线。
+
+### Phase 1：骨架、配置和运行模型（1–2 天）
+
+- 建立 `uv` 项目、CLI、配置 schema、核心实体、run 目录和 SQLite schema；
+- 接入 `pydantic-ai-slim`，建立 `models.yaml`、`ModelGateway`、测试模型和实际模型审计；
+- 实现 source registry 校验、结构化日志、doctor 和 dry-run；
+- 先用两个本地 fixture adapter 跑通全流程空壳。
+
+退出条件：没有真实网络也能生成完整审计产物，所有异常状态可区分。
+
+### Phase 2：第一方采集器（2–3 天）
+
+- 先实现通用 RSS/Atom；
+- 再实现 HN、GitHub、arXiv、Hugging Face API；
+- 最后实现一个受限 change-watch；
+- 为每个启用来源建立 fixture、contract test 和 live smoke。
+
+退出条件：十余个核心来源能稳定收集，单源故障不会变成空成功。
+
+### Phase 3：规范化、聚类和来源健康（2 天）
+
+- URL/time/text normalization；
+- 精确、近似和边界聚类；
+- 45 天历史去重 marker；
+- source health、质量门禁和 Actions Summary。
+
+退出条件：固定测试集无重复、无明显误合并，失败门禁符合预期。
+
+### Phase 4：正文、评分与编辑（2–3 天）
+
+- shortlist 正文抽取；
+- 可解释 scoring 和分类/厂商配额；
+- 用旧日报评测集比较至少两家云 provider，确定 `judge`、`editor` primary 与跨云 fallback；
+- 结构化模型评审、逐条写作、模板装配；
+- 事实/链接/marker/Markdown validator。
+
+退出条件：golden digest 可重复生成，所有深度条目有第一方证据，模型异常明确失败。
+
+### Phase 5：发布集成（1–2 天）
+
+- 实现 Issue 查找、创建、更新和 hash 幂等；
+- 修改现有发布端的 trusted bot 规则；
+- 把站点构建抽成可复用 workflow；
+- 实现页面/RSS verifier。
+
+退出条件：测试环境同日重复运行不产生重复 Issue，页面与 RSS 可验证。
+
+### Phase 6：全自动调度、切换与增强观察（1–2 天实施 + 7 天观察）
+
+- 在专用测试仓库完成全链路、幂等、恢复和 06:00 截止预算验证；
+- 正式启用 04:20 主任务、05:05 恢复和 05:45 最终校验，三个 schedule 从第一天就自动发布，不生成待审草稿；
+- 前 7 个正式发布日增强记录候选、漏报、误报、重复、fallback、成本、可见时间和发布后更正；
+- 发现 blocker 时自动停止错误发布并修复流水线，不恢复旧 OpenClaw 任务，也不改为日常人工审批；
+- 冻结首版来源、模型 profile、阈值和模板，保留幂等手动 rerun 作为故障处理工具。
+
+退出条件：测试仓库验收通过后即完成切换；随后连续 7 个生产日记录增强观察指标，至少一次自动恢复演练通过。
+
+预计工程量约 9–13 个有效开发日，另有 7 个自然日生产增强观察，但观察期不阻塞全自动发布；来源端点和模型质量可能影响实际时间。
+
+## 18. Action items
+
+- [ ] 将 `/Users/jessew/projects/ai-daily` 接入现有 `wjy9902/ai-daily` Git 历史，并先验证旧站点基线；任何 commit 前单独征得用户确认。
+- [ ] 在隔离 worktree 创建 Python 3.12 + `uv` 骨架、CLI、Ruff、类型检查和 pytest。
+- [ ] 定义 `SourceDefinition`、`FetchResult`、Item/Event/Digest/Publication schema 与 SQLite migration。
+- [ ] 安装最小 `pydantic-ai-slim` provider extras，定义 `models.yaml`、`ModelGateway`、显式 fallback 和 `ModelRun` 审计。
+- [ ] 建立 `sources.yaml`，逐个验证首版来源端点、许可、时间语义、速率限制和 fixture。
+- [ ] 实现异步 HTTP 基础设施：timeout、重试、per-host limit、条件请求、响应大小和 host allowlist。
+- [ ] 实现通用 RSS/Atom adapter，并完成 OpenAI、DeepMind、Google AI、Hugging Face、GitHub feeds 的契约测试。
+- [ ] 实现 HN、GitHub Releases、arXiv、Hugging Face Papers API adapters。
+- [ ] 实现一个只允许官方白名单页面的 change-watch adapter，并先接一个来源验证维护成本。
+- [ ] 实现规范化、canonical URL、精确去重、近似事件聚类和 45 天跨日报去重。
+- [ ] 实现逐来源 health report、整体质量门禁和脱敏 Actions Summary。
+- [ ] 实现 deterministic scoring、分类/厂商配额与 shortlist。
+- [ ] 实现 shortlist 正文抽取，记录 excerpt/full-text/error 的显式状态。
+- [ ] 用旧日报固定评测集比较至少两家云 provider，确定 `judge`/`editor` primary 与跨云 fallback，并完成严格 schema 和 prompt-injection 防护。
+- [ ] 实现日报模板、证据/链接/重复/Markdown validator 和 golden E2E fixture。
+- [ ] 实现 GitHub Issue marker、可信身份、create/update/no-op 幂等与未知状态查重。
+- [ ] 小步修改现有 site generator 以接受受信 bot Issue，并把 Pages 构建抽为复用 workflow。
+- [ ] 实现 Issue、页面、RSS 发布后验证以及 04:20/05:05/05:45 三段幂等恢复逻辑。
+- [ ] 在测试仓库验证全自动发布和 06:00 截止预算，再直接启用正式 schedule。
+- [ ] 完成失败注入、并发发布和回滚演练，形成短 runbook。
+- [ ] 正式发布前 7 天记录增强观察指标；后续来源和高频预采集全部作为独立变更评审。
+
+## 19. 已确认的产品决定
+
+1. **模型层**：采用 `pydantic-ai-slim` 作为可替换的进程内 provider 层；实际模型由固定评测选出并放入配置，不在业务代码中硬编码。OpenRouter 是可选 provider，LiteLLM/Portkey 首版不部署。
+2. **时间**：每天北京时间 06:00 前网站和 RSS 均可见；04:20 主运行、05:05 自动恢复、05:45 最终校验。
+3. **内容**：优先能改变产品/工程行动的官方模型能力、工具和开源项目；重要研究与国内/行业变化保持有限配额，传闻、泛融资和论文堆砌降权。
+4. **渠道**：只保留网站和 RSS，不恢复 Telegram、微信、邮件或其他内容推送。
+5. **发布方式**：正式环境全自动发布，没有人工审批/草稿确认环节；自动门禁、幂等恢复和发布后审计承担质量控制。

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -1,0 +1,31 @@
+# AI Daily
+
+这是“甲鱼 AI 日报”下一版的独立项目目录。当前阶段只完成了旧系统复盘、开源项目调研和实施规划，尚未初始化代码仓库，也没有安装、启动或部署任何新服务。
+
+## 当前结论
+
+- 日报不再依赖 OpenClaw；它应当是一个边界清楚、可单独运行和测试的小型流水线。
+- 不恢复 RagFlow、Redis、浏览器自动化平台或通用 Agent 平台。
+- 模型层采用 `pydantic-ai-slim`：可按配置切换不同云端 provider，也可以在本地显式选择 Ollama；项目不启动独立模型网关，Ollama 不会在生产故障时静默接管。
+- 第一阶段保留现有 GitHub Issues → GitHub Pages/RSS 的发布链路，先替换最混乱的采集与编辑部分。
+- 采集优先使用官方 RSS、官方 API 和公开协议；搜索结果页、登录态 Cookie、私有接口和浏览器模拟不进入首版核心链路。
+- 每天北京时间 06:00 前，网站和 RSS 必须可以看到当日日报；只保留这两个发布渠道。
+- 正式工作流全自动发布，不设人工审核或草稿确认环节；自动质量门禁不通过时宁可明确失败，也不发布残缺内容。
+
+## 文档
+
+- [完整实施计划](PLAN.md)：目标架构、数据模型、来源分层、调度、失败策略、测试、上线和验收标准。
+- [项目采集方式调研](research/collection-methods.md)：旧日报复盘，以及 12 个热门日报/信息采集项目的逐项源码调研。
+- [多云模型 Provider 层调研](research/model-provider-layer.md)：Pydantic AI、Instructor、LiteLLM、OpenRouter 等方案的对比与最终选型。
+
+## 现有发布资产
+
+- 公开网站：[甲鱼 AI 日报](https://wjy9902.github.io/ai-daily/)
+- 发布仓库：[wjy9902/ai-daily](https://github.com/wjy9902/ai-daily)
+- RSS：[rss.xml](https://wjy9902.github.io/ai-daily/rss.xml)
+
+现有仓库继续负责把 GitHub Issue 渲染为网站和 RSS。新项目第一阶段只负责生成经过验证的日报 Markdown，并幂等地创建或更新当天的 Issue。
+
+## 工作边界
+
+这个目录从现在起是日报项目的唯一工作目录。旧 OpenClaw 工作区只作为历史取证来源，不再作为运行时依赖，也不在这里复制旧系统的脚本、绝对路径、Cookie、代理配置或密钥。

--- a/docs/plan/research/collection-methods.md
+++ b/docs/plan/research/collection-methods.md
@@ -1,0 +1,460 @@
+# AI 日报与信息采集项目调研
+
+> 调研日期：2026-08-12（Asia/Shanghai）
+> 调研方式：阅读官方仓库的 README、工作流、配置和实际采集/存储源码；没有只根据项目宣传页下结论。Star 数仅用于说明社区热度，不代表架构质量。
+
+## 1. 调研范围与判断标准
+
+本次逐项检查了四件事：
+
+1. **数据究竟从哪里来**：官方 RSS/API、聚合 API、网页抓取、浏览器模拟，还是需要 Cookie/付费桥接。
+2. **如何保存和去重**：是否有持久状态、来源血缘、跨来源事件聚类和历史窗口。
+3. **如何调度和暴露失败**：并发、超时、重试、限流、空结果与失败是否能区分，定时任务是否真的启用。
+4. **适不适合我们的日报**：可借鉴什么、不能继承什么、部署和许可证成本多大。
+
+### 1.1 仓库快照
+
+| 项目 | 本次检查提交 | Star 快照 | 许可证 | 项目本质 |
+|---|---:|---:|---|---|
+| [Horizon](https://github.com/Thysrael/Horizon) | `5064bb9` | 8,798 | MIT | 端到端个性化资讯摘要 |
+| [TrendRadar](https://github.com/sansan0/TrendRadar) | `8ee2602` | 61,395 | GPL-3.0 | 中文热榜聚合、排名轨迹与推送 |
+| [AI News Radar](https://github.com/LearnPrompt/ai-news-radar) | `b5708e8` | 1,658 | MIT | 高频 AI 信号采集与静态雷达页 |
+| [DailyBrief](https://github.com/leiting-eric/DailyBrief) | `c9cebf9` | 317 | MIT | 多源抓取后一次性生成日报 |
+| [CloudFlare AI Insight Daily](https://github.com/justlovemaki/CloudFlare-AI-Insight-Daily) | `287cde1` | 1,769 | GPL-3.0 | 已迁移的旧版 Cloudflare 日报系统 |
+| [PrismFlowAgent](https://github.com/justlovemaki/PrismFlowAgent) | `6421449` | 81 | GPL-3.0 | 插件式 Agent/数据工作流平台 |
+| [RSSHub](https://github.com/DIYgod/RSSHub) | `e086c17` | 45,710 | AGPL-3.0 | 把网站/API 转换成 RSS 的路由服务 |
+| [changedetection.io](https://github.com/dgtlmoon/changedetection.io) | `aac6fcf` | 33,084 | Apache-2.0 | 网页变化监控服务 |
+| [Karakeep](https://github.com/karakeep-app/karakeep) | `a8df483` | 28,264 | AGPL-3.0 | 收藏、抓全文、归档和检索系统 |
+| [Huginn](https://github.com/huginn/huginn) | `580d708` | 49,776 | MIT | 自托管 IFTTT/Zapier 式 Agent 平台 |
+| [FreshRSS](https://github.com/FreshRSS/FreshRSS) | `d677efb` | 15,752 | AGPL-3.0 | 多用户 RSS 阅读器/聚合器 |
+| [Miniflux](https://github.com/miniflux/v2) | `106cdd0` | 9,572 | Apache-2.0 | 极简 RSS 阅读器/聚合器 |
+
+## 2. 先复盘：原日报到底是怎么做出来的
+
+旧日报不是一个普通 Python 应用，而是 **OpenClaw Agent + 定时 Prompt + 若干本机脚本 + GitHub 发布仓库** 拼出来的工作流。恢复出的 v7.1 系统文档显示，它大致按下面四段运行。
+
+### 2.1 调度
+
+| 时间 | 任务 | 作用 |
+|---|---|---|
+| 22:00 | 晚间预采集 | 提前收集欧美白天出现的信息 |
+| 04:00 | 凌晨补采集 | 补充晚间新信息和国内来源 |
+| 04:30 | 成稿并发布 | 选题、写作、创建 GitHub Issue |
+| 04:45 | 发布兜底 | 检查是否已发布，失败时重试 |
+
+这些任务由隔离的 `ribao` Agent 执行，历史配置使用 Claude Sonnet 4.6。调度思想是合理的，但运行依赖散落在 OpenClaw、Prompt、本机路径和外部工具中。
+
+### 2.2 采集
+
+主路径是 9 组通用 `web_search` 查询，覆盖 Hugging Face Daily Papers、Hacker News、GitHub Trending、OpenAI/Anthropic/DeepMind、arXiv、Product Hunt、Reddit、Bilibili 和中文科技媒体。
+
+补充脚本 `collect-extra-sources.py` 还负责：
+
+- YouTube：`yt-dlp` 搜索/取元数据；
+- RSS：`feedparser`；
+- Bilibili：公开 API；
+- 微信公众号：miku_ai/Sogou，加 Camoufox 浏览器模拟；
+- Exa：通过外部 MCP 调用。
+
+结果追加到 `raw_items.jsonl`。已发布项目放入 `reported_items.jsonl`，用最近 7 天的标题或 URL 精确匹配来排重。
+
+### 2.3 选题与写作
+
+旧规则每天选择 8–12 条，按以下权重打分：技术影响 35%、实用价值 25%、行业影响 20%、社区热度 10%、时效性 10%。成稿分为：
+
+- 2–3 条深度解读；
+- 4–5 条标准资讯；
+- 2–4 条快速浏览；
+- 技术、产品、商业标签；
+- 一段编辑观察或行动建议。
+
+这套产品形态值得保留：它不是无穷信息流，而是一份有取舍、可在几分钟内读完的编辑型日报。
+
+### 2.4 发布
+
+成稿先保存本地 Markdown，再发送 Telegram，并通过 `gh issue create` 创建到 [wjy9902/ai-daily](https://github.com/wjy9902/ai-daily)。发布仓库中的 GitHub Actions 在 Issue 变更后运行：
+
+1. `main.py` 使用 PyGithub 读取 Issues，生成首页备份和 RSS；
+2. `isite` 把 Issues 转换为 Zola 内容；
+3. Zola 构建静态站点；
+4. GitHub Pages 部署公开网站。
+
+这个发布边界是旧系统中最干净的部分：**Issue 是内容接口，网站/RSS 独立构建**。第一阶段应继续使用它。
+
+### 2.5 旧系统为什么越改越乱
+
+- 搜索结果而不是第一方接口承担了主采集职责，结果不稳定且可追溯性差。
+- 一个 Agent 同时负责采集、判断、写作、发布和异常兜底，失败边界不清楚。
+- 本机绝对路径、代理、Cookie、CLI、MCP 和浏览器自动化形成隐性运行环境。
+- 发布成功后清空原始池，缺少可复盘的候选集和逐来源运行报告。
+- 只做精确标题/URL 去重，没有把“多家报道同一事件”合并成一个事件。
+- 微信、Reddit、Bilibili 等受登录、风控或接口变化影响的来源被放在关键路径中。
+- 多处采用“失败就继续/换方法”，但没有把降级结果明确写进运行状态。
+
+结论不是恢复旧 OpenClaw，而是保留它的编辑格式与 Issues 发布接口，重写中间的可靠流水线。
+
+## 3. 项目逐项调研
+
+### 3.1 Horizon：最接近我们目标的架构参照
+
+核心证据：[scrapers 目录](https://github.com/Thysrael/Horizon/tree/5064bb9/src/scrapers)、[RSS 实现](https://github.com/Thysrael/Horizon/blob/5064bb9/src/scrapers/rss.py)、[去重 Prompt](https://github.com/Thysrael/Horizon/blob/5064bb9/src/ai/prompting/deduplication.py)。
+
+**采集方式**
+
+- 每种来源实现统一的异步 `fetch(since)` 接口，主流程用 `asyncio.gather` 并发执行。
+- Hacker News 直接使用 Firebase API，先取 top story ID，再取 item 和前几条评论。
+- RSS/Atom 使用 `feedparser`；单个 feed 可选 `trafilatura` 抽取原文正文。
+- GitHub 使用 REST API 读取用户公开事件和仓库 Release，Token 只用于提升限额。
+- Reddit 默认尝试公开网页/JSON/RSS，遇到 429 做有限重试。
+- Telegram 读取公开 `t.me/s/<channel>` 预览页，不要求机器人 Token。
+- X/Twitter 默认依赖 Apify actor，轮询任务后读取 Dataset；这是有费用和外部依赖的路径。
+- “GitHub 趋势”实际使用 OSS Insight 的 star gain API，不是抓 GitHub Trending 页面。
+- 另外包含 GDELT、Google News RSS 和 OpenBB 自选列表。
+
+**状态、去重与失败**
+
+- 规范化 URL 时删除 UTM 等跟踪参数，以规范 URL 合并相同条目，并保留内容最丰富的版本及合并后的元数据/评论。
+- 还可让模型根据标题、标签和摘要做主题级去重；模型失败时保留原列表。
+- 每个来源有 `success / empty / failure` 结果，局部失败不阻塞其余来源；全部来源失败才终止。
+- 没有成熟的长期原始数据仓或逐来源增量游标，主要按时间窗口重新抓取。
+- RSS 全文抽取失败会退回 feed 摘要，但这个退回在内容层面不够显式。
+
+**调度事实**
+
+README 给人“开箱即用定时任务”的印象，但实际文件是 [`daily-summary.yml.disabled`](https://github.com/Thysrael/Horizon/blob/5064bb9/.github/workflows/daily-summary.yml.disabled)。这是典型的文档与真实运行状态漂移，说明任何项目都必须检查工作流源码。
+
+**我们的取舍**
+
+- 借鉴：统一 adapter 契约、并发采集、逐来源报告、规范 URL 合并、主题级聚类、分类配额。
+- 不继承：整套 Jekyll/多渠道发布、Apify X 依赖、过宽的 AI 配置面、静默正文退回。
+- 结论：**最佳概念基线，但不整仓 Fork。**
+
+### 3.2 TrendRadar：强项是热榜轨迹，不是原始事实采集
+
+核心证据：[热榜 fetcher](https://github.com/sansan0/TrendRadar/blob/8ee2602/trendradar/crawler/fetcher.py)、[RSS fetcher](https://github.com/sansan0/TrendRadar/blob/8ee2602/trendradar/crawler/rss/fetcher.py)、[SQLite schema](https://github.com/sansan0/TrendRadar/blob/8ee2602/trendradar/storage/schema.sql)。
+
+**采集方式**
+
+- 中文热榜不是逐站抓取，而是请求 NewsNow API，默认形如 `.../api/s?id=<platform>&latest`。
+- 默认平台包括今日头条、百度、华尔街见闻、澎湃、Bilibili 热搜、财联社、凤凰、贴吧、微博、抖音和知乎。
+- 来源按顺序请求，加入随机间隔，失败重试两次；同时校验 HTTPS 和预期域名，域名不符时整源丢弃。
+- RSS/Atom/JSON Feed 使用 `requests + feedparser`，保存标题、URL、GUID、时间、作者及最多 500 字摘要；主采集器不抓文章全文。
+- 可以把 NewsNow 自托管，但这等于新增一个长期维护服务。
+
+**状态、去重与失败**
+
+- SQLite 持久化新闻、标题变化、每次排名、采集批次和逐来源状态。
+- 热榜按 `URL + platform` 唯一；RSS 按 `guid + feed` 或 `URL + feed` 唯一。
+- 支持本地 SQLite，也支持 S3/R2 远程状态。
+- 报告模式有当天、当前、增量；可做关键词或 AI 标题分类，并根据排名历史分析趋势。
+- AI 过滤失败时会回落到关键词过滤，若不额外记录容易隐藏模型故障。
+
+**调度事实**
+
+GitHub Actions 每小时第 33 分钟运行，但默认有 7 天“签到试用”自停逻辑；长期运行官方更推荐 Docker。Actions 的本地 SQLite 不会天然跨 runner 保留，必须配置远程存储。
+
+**我们的取舍**
+
+- 借鉴：排名轨迹、逐来源状态、域名安全校验。
+- 可选接入：把 NewsNow/TrendRadar 结果作为“中国热度信号”，不能把热榜标题直接当作事实依据。
+- 不继承：完整推送/MCP/AI 配置系统、7 天自停模型、GPL 源码。
+- 结论：**第二阶段可选信号源，不是主采集器。**
+
+### 3.3 AI News Radar：来源治理最好，但实现已经单体化
+
+核心证据：[主采集脚本](https://github.com/LearnPrompt/ai-news-radar/blob/b5708e8/scripts/update_news.py)、[来源覆盖文档](https://github.com/LearnPrompt/ai-news-radar/blob/b5708e8/docs/SOURCE_COVERAGE.md)、[工作流](https://github.com/LearnPrompt/ai-news-radar/blob/b5708e8/.github/workflows/update-news.yml)。
+
+**采集方式**
+
+- 第一方来源包括 OpenAI、DeepMind、Google AI、Hugging Face Blog、GitHub AI/Changelog 等 RSS，以及 GitHub commit Atom。
+- Hacker News 用 Algolia 关键词搜索，并按评论数或分数过滤。
+- 支持 OPML 导入和大量媒体 RSS，按来源设置上限、关键词和质量先验。
+- 也接入 AI HOT、NewsNow、BestBlogs、Zeli、AIbase、Follow Builders 等聚合服务，部分页面使用 `requests + BeautifulSoup` 解析。
+- 被阻挡或需要更多上下文的页面有 Jina Reader 路径。
+- AgentMail、X 官方 API、SocialData、TikHub 等付费/私有来源被单独配置预算和状态。
+- 项目明确默认跳过不稳定的 RSSHub Telegram、即刻、Bilibili、知乎、播客和微信公众号桥接路由，有官方 feed 时优先替换。
+
+**状态、去重与编辑**
+
+- `archive.json` 保存 21 天，条目 ID 由站点、来源、标题和 URL 哈希生成，并记录首次/最后出现时间。
+- 独立输出 `source-status.json` 和付费来源状态，来源血缘与审计性较强。
+- 先用可解释的关键词、来源先验和 AI 相关性规则筛选；LLM 主要用于标题改善、翻译、推荐理由和人群说明。
+- 精确标题/URL 去重之外，还会按 canonical URL 或标题相似度合并 6 小时内的同一故事，并用厂商/模型实体保护降低误合并。
+- 重要性综合编辑权重、来源等级、AI 相关性、时效和多源热度；多来源或高分事件才进入重点摘要。
+
+**主要问题**
+
+- 绝大多数采集逻辑堆在约 6,500 行的 `update_news.py` 中，来源选择器和聚合服务硬编码很多。
+- 多层聚合会让“原始出处”和“发现渠道”混在一起。
+- README 称每 30 分钟更新，实际工作流是每小时第 17 分钟。
+- 工作流每小时把整个 `data/` 提交回仓库，历史审计直接，但会造成提交噪声与状态耦合。
+
+**我们的取舍**
+
+- 借鉴：来源等级、健康报告、确定性预过滤、事件合并记录、宁缺毋滥。
+- 不继承：巨型单文件、多层下游聚合、每小时提交数据快照、复杂付费桥接。
+- 结论：**最佳来源治理参考，不能直接成为代码底座。**
+
+### 3.4 DailyBrief：来源注册表和幂等调度值得借鉴
+
+核心证据：[来源配置](https://github.com/leiting-eric/DailyBrief/blob/c9cebf9/sources.config.json)、[来源分发](https://github.com/leiting-eric/DailyBrief/blob/c9cebf9/lib/sources/dispatch.ts)、[定时工作流](https://github.com/leiting-eric/DailyBrief/blob/c9cebf9/.github/workflows/daily.yml)。
+
+**采集方式**
+
+- 配置中共有 53 个来源、默认启用 26 个：21 个 RSS、4 个 API、1 个 HTML 抓取。
+- AI 来源包括 OpenAI、DeepMind、Hugging Face Blog、Hugging Face Daily Papers API、TLDR AI、Latent Space、GitHub Trending HTML、Hacker News Firebase 等。
+- RSS 用 `rss-parser`，15 秒超时、最多 30 条、截取约 300 字摘要；部分 TLS 问题用 `curl` 子进程绕过。
+- GitHub Trending 用 Cheerio 抓 HTML；Hugging Face Papers 用 API 并按关键词/赞数过滤；HN 只取分数和评论数，不取评论正文。
+- 还包含 V2EX、LinuxDo、金融和全球新闻，以及一个反向分析的第三方 X 排行 API。
+
+**处理方式**
+
+- 各来源顺序抓取，单源异常后继续；只有总结果为 0 才终止。
+- 以分类轮转方式限制候选，保留 14 天最大窗口。
+- 主流程没有清晰的跨来源事件聚类；LLM 基本只拿标题、URL 和短摘要一次性生成整份 JSON/HTML。
+- Actions 每小时两次触发，再由时段 gate 和“当天是否已有报告”判断是否执行，支持错过时间后的 catch-up。
+
+**我们的取舍**
+
+- 借鉴：声明式来源注册表、启动时配置校验、时段 gate、按日期幂等和 catch-up。
+- 不继承：过宽的金融/交易范围、HTML Trending、第三方 X 接口、只用短摘要的一次性整稿。
+- 结论：**适合借来源注册和发布幂等，不适合直接 Fork。**
+
+### 3.5 CloudFlare AI Insight Daily：已经是遗留实现
+
+核心证据：[旧数据源目录](https://github.com/justlovemaki/CloudFlare-AI-Insight-Daily/tree/287cde1/src/dataSources)、[构建工作流](https://github.com/justlovemaki/CloudFlare-AI-Insight-Daily/blob/287cde1/.github/workflows/build-daily-book.yml)。
+
+**采集方式**
+
+- 旧实现运行在 Cloudflare Worker/KV，包含 GitHub 项目、Hugging Face Papers、中文 AI 媒体等 adapter。
+- Reddit/X 依赖 Folo 的内部接口、`FOLO_COOKIE`、列表 ID 和分页详情，不是稳定的官方公开协议。
+- GitHub、Folo、模型、登录和 Worker URL 等环境变量很多。
+- 日报 book 工作流中的 schedule 已注释，主要靠手动触发和外部 Worker URL，再把结果提交到分支。
+
+README 已明确后端迁往 PrismFlowAgent，因此这个仓库不是仍在演进的采集核心。
+
+**我们的取舍**
+
+- 不复制任何实现，也不恢复 Folo Cookie/私有接口。
+- 仅把它作为“为什么不要让 Workers、Cookie、模型和 GitHub commit 混成一个任务”的反例。
+- 结论：**不采用。**
+
+### 3.6 PrismFlowAgent：插件平台能力多，但边界过大
+
+核心证据：[BaseAdapter](https://github.com/justlovemaki/PrismFlowAgent/blob/6421449/src/plugins/base/BaseAdapter.ts)、[内置 adapters](https://github.com/justlovemaki/PrismFlowAgent/tree/6421449/src/plugins/builtin/adapters)、[SchedulerService](https://github.com/justlovemaki/PrismFlowAgent/blob/6421449/src/services/SchedulerService.ts)。
+
+**采集方式**
+
+- Fastify + React + SQLite 的完整应用，通过扫描内置/自定义目录注册 adapter。
+- Adapter 先 `fetch` 原始数据，再 `transform` 为统一数据。
+- RSS adapter 使用 `rss-parser`；GitHub Trending 用 HTML 正则；Follow adapter 仍依赖 Folo 内部 API 与 Cookie。
+- AI Search adapter 让 Agent 自己搜索并返回 JSON，这更像不确定的发现工具，不是可审计的一手采集。
+
+**状态与失败**
+
+- SQLite 保存 `source_data`、全文索引、状态和日志；调度时区为 Asia/Shanghai。
+- 来源 adapter 默认顺序执行。
+- `BaseAdapter` 捕获异常后返回空数组，后续任务仍可能被标为成功；这会把“来源失败”伪装成“今天没有内容”。
+- 主键主要是 adapter 产生的 `id`，缺少成熟的规范 URL 唯一性和跨来源事件聚类。
+
+**我们的取舍**
+
+- 只借鉴 `fetch → transform` 的接口思想；Horizon 的契约更小、更适合本项目。
+- 不引入后台、前端、插件注册、Agent 编排、Docker 镜像和 SSH 部署面。
+- 结论：**对一个人维护的日报明显过重，不采用。**
+
+### 3.7 RSSHub：是协议转换层，不是日报采集系统
+
+核心证据：[路由源码](https://github.com/DIYgod/RSSHub/tree/e086c17/lib/routes)。
+
+**采集方式**
+
+- 每个 HTTP 路由在请求到来时调用上游 API 或解析网页，再即时输出 RSS item。
+- 例如 Bilibili 热门路由直接调用 Bilibili 公开 API，把标题、描述、发布时间、链接和作者映射成 feed。
+- 数千条路由中，有些只需公开 API，有些需要 Cookie、代理、配置或 Puppeteer；路由元数据会声明反爬和配置要求。
+- 服务层提供缓存和访问控制。
+
+**它没有做的事**
+
+- 不主动轮询全部来源；
+- 不持久化我们的候选池；
+- 不做跨 feed 去重、事件聚类、重要性排序或编辑；
+- 路由是否稳定仍取决于上游页面/API。
+
+**我们的取舍**
+
+- 当某个必要来源确实没有官方 RSS/API 时，可以把一条经过固定和监控的 RSSHub 路由当作普通 feed。
+- 首版不自托管 RSSHub；只有至少 3–5 条不可替代路由长期证明有价值后才评估。
+- 不复制 AGPL 路由源码到本项目。
+- 结论：**可选的末级转换器，不进入核心。**
+
+### 3.8 changedetection.io：适合盯官方更新页，不适合发现全网新闻
+
+核心证据：[fetch backends](https://github.com/dgtlmoon/changedetection.io/tree/aac6fcf/changedetectionio/content_fetchers)、[RSS 输出](https://github.com/dgtlmoon/changedetection.io/tree/aac6fcf/changedetectionio/blueprint/rss)。
+
+**采集方式**
+
+- 每个 watch 指定一个 URL，可用快速 HTTP requests，也可用 Playwright、Puppeteer 或 Selenium 浏览器。
+- 支持 headers、Cookie、代理、GET/POST、浏览器步骤和登录流程。
+- CSS/XPath、JSONPath/jq 和文本过滤器只比较页面的有效区域。
+- 保存历史快照，按 checksum/diff 判断变化；还支持库存、图片变化、截图和通知。
+- 可按 watch 设置时区/周期，并把变化输出为 RSS。
+
+**我们的取舍**
+
+- 很适合监视 5–15 个没有 feed 的**官方发布页或 Changelog**，例如 Anthropic News。
+- 页面变化只是“可能有新信息”，还必须经过提取、规范化和编辑验证，不能直接变成日报条目。
+- 首版优先写一个受限的轻量 change-watch adapter；如果页面规则越来越多，再把 changedetection.io 作为旁路服务接入。
+- 结论：**明确的补充能力，不作为核心平台。**
+
+### 3.9 Karakeep：先收藏再深抓，适合人工资料库
+
+核心证据：[RSS 文档](https://github.com/karakeep-app/karakeep/blob/a8df483/docs/docs/05-integrations/06-rss-feeds.md)、[FeedWorker](https://github.com/karakeep-app/karakeep/blob/a8df483/apps/workers/workers/feedWorker.ts)、[Crawler](https://github.com/karakeep-app/karakeep/tree/a8df483/apps/workers/workers/crawler)。
+
+**采集方式**
+
+- 每小时扫描启用的 RSS feed，并按 feed ID 哈希把任务均匀分布在一小时内。
+- 每次请求 5 秒超时，要求 HTTP 200 和 XML content type。
+- `rss-parser` 只规范 `id/link/guid/title/categories`，GUID 依次退回到 id 或 link。
+- `rss_feed_imports` 记录 `feed + entryId`；新条目创建为 bookmark，再进入后续 crawler。
+- Crawler 可用浏览器抓页面、解析正文和元数据、截图、PDF、完整页面归档；视频还可使用 yt-dlp。
+- 后续支持 LLM 标签/摘要、OCR、全文和向量检索，也支持本地 Ollama。
+
+**代价与定位**
+
+- 它需要 Web、数据库、队列、worker、浏览器和资产存储，是完整的个人知识库，不是一个小型 collector。
+- Feed 到 bookmark 的链路非常适合“我以后要读”，但没有为日报设计事件聚类、来源证据和编辑配额。
+
+**我们的取舍**
+
+- 借鉴：先收候选、只对 shortlist 抓全文；失败状态与原始摘要分开保存。
+- 如果未来需要个人复核箱，可以把候选单向导入 Karakeep；不能让它成为日报运行前提。
+- 结论：**可选人工阅读/归档旁路，不安装为核心。**
+
+### 3.10 Huginn：通用事件 Agent 很灵活，也会重新制造复杂度
+
+核心证据：[RSS Agent](https://github.com/huginn/huginn/blob/580d708/app/models/agents/rss_agent.rb)、[Website Agent](https://github.com/huginn/huginn/blob/580d708/app/models/agents/website_agent.rb)、[De-duplication Agent](https://github.com/huginn/huginn/blob/580d708/app/models/agents/de_duplication_agent.rb)。
+
+**采集方式**
+
+- RSS Agent 基于 Feedjira，默认每天执行；支持多 feed、headers、Basic Auth、清洗和每次条目上限。
+- 它在 agent memory 中记住最近 ID，默认 500 个；多 feed 中相同 GUID 被视为重复。
+- Website Agent 支持 HTML/XML 的 CSS/XPath、JSONPath、文本正则，以及 `all / on_change / merge` 模式。
+- Agent 之间通过数据库事件图传播，可再串接去重、格式转换、Digest、邮件、Webhook 等 Agent。
+- Scheduler 用 Rufus/后台任务支持分钟、小时、每天和自定义 cron。
+
+**状态与失败**
+
+- 网站抓取异常写 Agent log，不发事件；working 状态结合预期更新周期和近期错误。
+- 通用去重 Agent 对配置属性做有限 lookback，长属性使用 CRC32；这不等同于 URL 规范化或语义事件聚类。
+- 部署需要 Rails、数据库、队列/worker 和大量通用 Agent 配置。
+
+**我们的取舍**
+
+- 它能复刻旧 OpenClaw 的“拖 Agent 流程”，但会再次把简单日报变成一个通用自动化平台。
+- 本项目需要显式代码、类型和测试，不需要可视化 Agent 图。
+- 结论：**不采用。**
+
+### 3.11 FreshRSS：成熟的订阅阅读器，不是编辑流水线
+
+核心证据：[README](https://github.com/FreshRSS/FreshRSS/blob/d677efb/README.md)、[Feed 更新文档](https://github.com/FreshRSS/FreshRSS/blob/d677efb/docs/en/admins/08_FeedUpdates.md)、[网站抓取文档](https://github.com/FreshRSS/FreshRSS/blob/d677efb/docs/en/users/11_website_scraping.md)。
+
+**采集方式**
+
+- 支持 RSS、Atom、JSON Feed、OPML，以及兼容来源的 WebSub 实时推送。
+- 内置网页抓取可用 XPath 1.0 从 HTML 生成 feed，也能用 dotted path 解析 JSON。
+- `actualize_script.php` 由 Docker cron、系统 cron 或 systemd 触发；单 feed 最快约每 20 分钟更新一次。
+- 基于 SimplePie/cURL 请求，默认 10 秒级超时，处理重定向和 429/503 `Retry-After`。
+- 条目和 feed 状态保存在 SQLite、PostgreSQL、MariaDB/MySQL 中，适合长期未读/收藏管理。
+
+**我们的取舍**
+
+- 强项是订阅管理、阅读状态、多用户 UI 和客户端 API；它不做 AI 选题、跨 feed 事件聚类或证据验证。
+- 如果未来想要一个人工 RSS 收件箱，可以单独使用；新日报不应为此增加 PHP Web 服务和数据库。
+- 结论：**不作为运行依赖。**
+
+### 3.12 Miniflux：最值得参考的可靠 feed 拉取实现
+
+核心证据：[README](https://github.com/miniflux/v2/blob/106cdd0/README.md)、[调度器](https://github.com/miniflux/v2/blob/106cdd0/internal/cli/scheduler.go)、[RefreshFeed](https://github.com/miniflux/v2/blob/106cdd0/internal/reader/handler/handler.go)。
+
+**采集方式**
+
+- 支持 Atom、RSS、JSON Feed、OPML，默认约一小时轮询。
+- 持久保存 ETag 和 Last-Modified，发出条件请求；未修改时不重复解析正文。
+- 参考 feed TTL、Cache-Control、Expires、历史更新频率和 `Retry-After` 安排下次检查。
+- Scheduler 按 batch、解析错误上限和每 host 并发上限生成任务，worker pool 并行刷新。
+- 保存 feed error counter，解析失败、数据库失败和限流都有明确状态。
+- 可按 CSS 规则抓原文，也有本地 Readability 全文提取、过滤规则和 REST API。
+
+**代价与定位**
+
+- 单 Go binary 很轻，但强制 PostgreSQL；一旦采用就新增常驻服务和数据库。
+- 它解决的是可靠读 feed，不解决多来源事件、选题和日报写作。
+
+**我们的取舍**
+
+- 借鉴：条件 HTTP、按 host 限流、`success/not-modified/failure` 分离、错误计数、动态刷新时间。
+- 首版直接在 Python adapter 中实现所需的小子集，不部署 Miniflux。
+- 结论：**优秀实现参考，不作为服务依赖。**
+
+## 4. 横向对比
+
+| 项目 | 第一方 RSS/API | 热榜/社交 | 网页变化 | 持久采集历史 | 跨源事件合并 | 编辑型日报 | 部署负担 | 对本项目的角色 |
+|---|---|---|---|---|---|---|---|---|
+| Horizon | 强 | 中 | 弱 | 弱 | 强 | 强 | 中 | 核心架构参照 |
+| TrendRadar | RSS 中、热榜依赖聚合 API | 强 | 无 | 强 | 弱 | 中 | 中 | 中文热度旁路 |
+| AI News Radar | 强 | 强 | 中 | 中 | 强 | 中 | 中 | 来源治理参照 |
+| DailyBrief | 中 | 中 | 弱 | 弱 | 弱 | 中 | 低 | 注册表/幂等参照 |
+| CloudFlare AI Insight | 中 | 私有桥接多 | 弱 | 中 | 弱 | 中 | 高 | 不采用 |
+| PrismFlowAgent | 中 | 中 | 弱 | 中 | 弱 | 中 | 高 | 不采用 |
+| RSSHub | 路由转换 | 强 | 路由级 | 缓存而非历史 | 无 | 无 | 中至高 | 末级 feed 转换器 |
+| changedetection.io | 无 | 无 | 强 | 强 | 无 | 无 | 中 | 官方页面补充监控 |
+| Karakeep | RSS 中 | 无 | 抓全文 | 强 | URL 级 | 无 | 高 | 可选人工归档箱 |
+| Huginn | 中 | 取决于 Agent | 强 | 事件级 | 简单属性去重 | Digest 而非编辑 | 高 | 不采用 |
+| FreshRSS | 强 | 无 | XPath/JSON | 强 | feed 条目级 | 无 | 中 | 可选个人阅读器 |
+| Miniflux | 强 | 无 | CSS/全文 | 强 | feed 条目级 | 无 | 中 | feed 可靠性参照 |
+
+## 5. 能力怎么组合，而不是项目怎么堆叠
+
+研究后的合理组合是“借能力、少依赖”：
+
+| 我们需要的能力 | 主要借鉴 | 实际采用方式 |
+|---|---|---|
+| 小而统一的来源接口 | Horizon | 自己实现 `fetch → normalize` adapter 契约 |
+| 来源等级、血缘和健康报告 | AI News Radar | 写入本项目的数据模型和运行产物 |
+| 排名变化/热度轨迹 | TrendRadar | 第二阶段可选数据字段或外部信号 adapter |
+| 声明式来源配置和日期幂等 | DailyBrief | YAML 注册表 + 发布标记 |
+| 条件请求、限流、错误计数 | Miniflux | 在 RSS/API 基础设施中实现必要子集 |
+| 无 RSS 官方页面变化 | changedetection.io | 少量受限 change-watch adapter，必要时外接服务 |
+| 只为 shortlist 抓全文 | Karakeep/Horizon | 先筛选，再用轻量正文抽取，不全网归档 |
+| 网站和 RSS 发布 | 现有 ai-daily 仓库 | 继续以 GitHub Issue 为内容接口 |
+
+明确不组合的东西：
+
+- 不同时部署 TrendRadar、RSSHub、Karakeep、Huginn、FreshRSS、Miniflux 和 PrismFlowAgent；
+- 不把 Cookie、Folo 私有接口、X 抓取或浏览器登录放进首版；
+- 不把通用搜索/Agent 输出当作事实来源；
+- 不把采集、写作和发布塞进一个大脚本；
+- 不因为某项目 Star 多就接受它的运行边界。
+
+## 6. 许可证边界
+
+- MIT 项目（Horizon、AI News Radar、DailyBrief、Huginn）允许在保留许可和版权说明的条件下复用，但本项目优先重写所需的小接口，避免携带不必要结构。
+- Apache-2.0 项目（changedetection.io、Miniflux）可作为算法和工程参考，若复制具体代码需保留通知并检查专利条款。
+- GPL/AGPL 项目（TrendRadar、CloudFlare AI Insight、PrismFlowAgent、RSSHub、Karakeep、FreshRSS）不复制或 vendoring 源码到本项目。通过公开 HTTP/RSS 协议消费一个独立服务，与把其代码嵌入项目是两件事。
+- 以上是降低许可证耦合的工程策略，不是法律意见。
+
+## 7. 最终判断
+
+没有一个现成项目能同时满足“来源可靠、中文 AI 聚焦、跨源合并、编辑质量高、运行简单、沿用现有站点”这六点。直接安装其中任何一个，都只是在另一处制造新的耦合。
+
+最合理的路线是：
+
+1. 用 Horizon 的 adapter/并发/来源报告作为结构参考；
+2. 用 AI News Radar 的来源等级、血缘和事件合并作为质量参考；
+3. 用 Miniflux 的条件请求和失败状态作为采集可靠性参考；
+4. 用 DailyBrief 的注册表与幂等调度作为运维参考；
+5. 继续使用现有 GitHub Issues → Pages/RSS 发布层；
+6. 从一个每日单次、十余个高质量来源的小系统开始，质量稳定后再增加热榜和高频采集。
+
+具体落地步骤见项目根目录的 [PLAN.md](../../PLAN.md)。

--- a/docs/plan/research/model-provider-layer.md
+++ b/docs/plan/research/model-provider-layer.md
@@ -1,0 +1,149 @@
+# 多云模型 Provider 层调研
+
+> 调研日期：2026-08-12（Asia/Shanghai）
+> 目标：让日报可以在 OpenAI、Anthropic、Google、DeepSeek、OpenRouter 和本机 Ollama 等模型之间改配置切换，同时保持结构化输出、错误可见和低运维。
+
+## 1. 我们实际需要什么
+
+日报不是聊天机器人，也不需要模型调用网关的后台管理系统。它只需要：
+
+1. 用统一的 `provider:model` 配置选择不同云模型；
+2. 把事件评审和日报条目解析为 Pydantic 类型，而不是自己截取 JSON；
+3. 支持 async、timeout、有限重试、用量记录和测试替身；
+4. 可以配置跨 provider 的故障链，但实际用了哪个模型必须可审计；
+5. 模型切换不能影响采集、聚类、验证和发布代码；
+6. 不增加 Redis、数据库、常驻 proxy、控制台或另一套部署。
+
+因此，“支持最多 provider”不是第一标准。边界小、结构化输出可靠和失败语义明确更重要。
+
+## 2. 候选项目
+
+Star 数是 2026-08-12 的页面快照，只用于说明项目成熟度，不作为选型分数。
+
+| 项目 | Star 快照 | 许可证/形态 | 适配范围 | 结构化输出 | 跨模型故障链 | 额外服务 | 结论 |
+|---|---:|---|---|---|---|---|---|
+| [Pydantic AI](https://github.com/pydantic/pydantic-ai) | 19.2k | MIT，Python 库 | 原生主流 provider + OpenAI-compatible + OpenRouter/Ollama | Pydantic 原生 | `FallbackModel` | 无，提供 slim 安装 | **采用** |
+| [Instructor](https://github.com/567-labs/instructor) | 13.7k | MIT，Python 库 | 主流云、OpenRouter、LiteLLM、Ollama | 核心强项 | 没有同等完整的统一故障模型 | 无 | 最轻量备选 |
+| [LiteLLM](https://github.com/BerriAI/litellm) | 56.2k | 核心 MIT，SDK/网关 | 100+ provider | 支持 JSON Schema/Pydantic | Router 重试、冷却、fallback | SDK 可无；网关会新增服务 | 暂不采用 |
+| [aisuite](https://github.com/andrewyng/aisuite) | 16.1k | MIT，Python 库 | OpenAI、Anthropic、Google、Ollama 等 | 不是主要设计中心 | 需自行设计 | 无 | 不如前两者匹配 |
+| [OpenRouter](https://openrouter.ai/docs/quickstart) | SaaS | 托管聚合 API | 数百模型/多下游 provider | 支持，但取决于模型/路由端点 | 默认有 provider fallback | 无自托管服务，但新增中间商 | 可选 provider，不做唯一入口 |
+| [Portkey Gateway](https://github.com/Portkey-AI/gateway) | 12.7k | MIT，网关/托管服务 | 250+ LLM | OpenAI-compatible | 重试、fallback、负载均衡 | 需要 gateway 进程或托管服务 | 对单日报过重 |
+| [BAML](https://github.com/BoundaryML/baml) | 8.9k | Apache-2.0，独立语言/运行时 | 多 provider | 强类型 | 有运行时能力 | 新语言、编译和生成层 | 对本项目过重 |
+
+## 3. 逐项判断
+
+### 3.1 Pydantic AI：最符合完整需求
+
+官方文档显示它支持 OpenAI、Anthropic、Gemini、xAI、Bedrock、Mistral、Groq、OpenRouter 等原生 provider，并可通过 OpenAI-compatible provider 接入 DeepSeek、Together、Fireworks、Ollama 等端点。模型可以用 `provider:model` 字符串声明，也可以在运行时替换。
+
+与日报直接相关的能力：
+
+- 输出类型就是 Pydantic model，校验失败会按明确预算让同一模型重试；
+- model profile 可以在调用前检查 JSON Schema 等能力；
+- `FallbackModel` 可以按顺序尝试跨 provider 模型，并保留最终 `model_name`；
+- HTTP 错误保留状态码、headers 和 `Retry-After`；
+- 支持并发限制、timeout、request/token/cost limits；
+- `TestModel` 和 `FunctionModel` 适合不调用真实 API 的单元/E2E 测试；
+- [`pydantic-ai-slim`](https://ai.pydantic.dev/install/) 可以只安装 `openai`、`anthropic`、`google`、`openrouter` 等需要的 extra，不必安装 CLI、MCP、Web UI、Logfire 和 durable execution。
+
+它的完整产品是 Agent framework，但我们只使用其中的 typed model/provider/output 部分：不注册工具，不启用 MCP、图、Web UI、Logfire 或多 Agent。这样不会改变日报的确定性流水线边界。
+
+### 3.2 Instructor：非常合适的轻量备选
+
+[Instructor provider 文档](https://python.useinstructor.com/integrations/)支持 OpenAI、Anthropic、Google、DeepSeek、Bedrock、Vertex、Groq、OpenRouter、LiteLLM、Ollama 等，并统一提供 Pydantic response model、验证重试、async 和 hooks。
+
+如果需求只有“切模型 + 获取可靠 JSON”，Instructor 的边界比 Pydantic AI 更小。它没有同等完整的模型 profile、用量限制和跨 provider `FallbackModel` 语义；为满足 06:00 全自动发布的故障链，我们还要自己写一层模型错误分类和 fallback。综合后，Pydantic AI Slim 更少自研代码。
+
+### 3.3 LiteLLM：能力最广，但现在不需要网关
+
+[LiteLLM](https://github.com/BerriAI/litellm)既能作为 Python SDK，也能运行 OpenAI-compatible AI Gateway。它支持 100+ provider、Pydantic/JSON Schema、模型 alias、重试、冷却、fallback、成本和路由；[Router 文档](https://docs.litellm.ai/docs/routing)还提供跨部署负载均衡。
+
+这些能力更适合多个应用、多个团队或大请求量。Router 的生产级用量/冷却状态会引入 Redis，Proxy 又新增常驻服务、控制台和密钥层。日报每天只有一批调用，先引入它会扩大故障面。未来若多个本机项目都需要统一模型预算、密钥、审计和路由，再单独评估 LiteLLM Gateway。
+
+### 3.4 aisuite：统一调用很轻，但结构化契约较弱
+
+[aisuite](https://github.com/andrewyng/aisuite)提供 OpenAI 风格的 Chat Completions，用一个 `provider:model` 字符串切换 OpenAI、Anthropic、Google、Ollama 等 provider，基础包也不强装所有 SDK。
+
+它适合统一普通聊天调用，但官方当前把工具和 Agent API 也扩进了项目；结构化输出、provider capability profile 和跨云失败策略不是它相对 Pydantic AI/Instructor 的优势。日报强依赖严格 schema，因此不选。
+
+### 3.5 OpenRouter：便利的可选入口，不应默认成为中间层
+
+[OpenRouter Quickstart](https://openrouter.ai/docs/quickstart)提供一个 API 访问数百模型，可以通过 Pydantic AI 的 `openrouter:` provider 使用。它特别适合临时比较模型，或用户只想维护一个账户/Key 的场景。
+
+但它在直连厂商之外新增一个数据和可用性中间层。其[路由文档](https://openrouter.ai/docs/guides/routing/provider-selection)显示，默认会在下游 provider 间做负载均衡和 fallback，且数据策略需要显式配置。若启用，日报必须：
+
+- 指定确切 model slug，不使用会自动漂移的 `latest`/auto router；
+- `require_parameters=true`，确保下游支持所请求的结构化参数；
+- 默认 `allow_fallbacks=false`，由我们的显式模型链控制故障切换；
+- `data_collection=deny`，能满足时再加 `zdr=true`；
+- 记录实际下游 provider/model，并验证 structured output 能力。
+
+因此 OpenRouter 是配置中的一个可选 provider，不是所有调用的必经网关。
+
+### 3.6 Portkey 与 BAML：解决了更大的问题
+
+Portkey 是完整 AI Gateway，提供重试、fallback、负载均衡、guardrail、日志和密钥控制；BAML 现在是带类型系统、编译/代码生成和测试能力的 Agent 编程语言。两者都能实现需求，但会为一个每日批处理引入新的运行面或语言层，不符合“干净日报”的目标。
+
+## 4. 最终方案
+
+### 4.1 采用方式
+
+- 使用 `pydantic-ai-slim`，只安装当前启用 provider 的 extras。
+- 在项目内定义一个很小的 `ModelGateway` 接口，业务代码只认识 `assess()`、`write_item()` 和 typed output，不直接 import 厂商 SDK。
+- 模型名称、角色、timeout、token/cost budget 和显式 fallback 链放在 `config/models.yaml`；API key 只从环境变量/GitHub Secrets 读取。
+- Ollama 作为一个可选择的本地 profile，绝不在云模型失败时自动接管生产任务。
+- 不启动 Pydantic AI Gateway、LiteLLM Proxy、Portkey 或任何模型控制台。
+
+概念配置：
+
+```yaml
+profiles:
+  judge:
+    primary: "<provider>:<model>"
+    fallbacks:
+      - "<different-provider>:<model>"
+    timeout_seconds: 90
+    output_retries: 1
+  editor:
+    primary: "<provider>:<model>"
+    fallbacks:
+      - "<different-provider>:<model>"
+    timeout_seconds: 120
+    output_retries: 1
+```
+
+这里的 fallback 是显式配置，不是自动选择“便宜/快的任意模型”。每次调用都记录 profile、请求模型、实际模型、fallback 原因、耗时、tokens 和可用成本数据。
+
+### 4.2 故障规则
+
+- 只在 timeout、连接失败、429、可恢复 5xx 等 provider/API 故障时进入下一个模型。
+- Authentication、bad request、context overflow、schema 配置错误立即失败，不用另一个模型掩盖配置问题。
+- 输出校验失败先在同一模型内重试一次；仍失败则该阶段失败，不把未经验证文本交给下一阶段。
+- fallback 被使用不是“正常无事发生”：写入 `model-runs.json` 和 Actions Summary。
+- 所有模型都失败时停止发布，并由 05:05 的自动恢复运行重新执行；不生成标题拼接版日报。
+
+### 4.3 初始模型怎么选
+
+计划不在文档中硬编码一个会过期的模型名。实现阶段用最近 20–30 期旧日报构建固定评测集，对至少两家独立云 provider 的候选模型比较：
+
+| 维度 | 权重 |
+|---|---:|
+| 对证据的忠实度、无虚构 | 35% |
+| 选题准确率与漏报 | 20% |
+| 结构化输出一次通过率 | 15% |
+| 中文编辑质量 | 15% |
+| 端到端延迟和稳定性 | 10% |
+| 单期成本 | 5% |
+
+得分最高的模型作为 `editor.primary`；便宜、稳定且判断一致的模型可以作为 `judge.primary`。fallback 必须来自另一家 provider，避免单云故障。模型切换只改配置并重新跑同一组评测与 smoke test，不修改业务代码。
+
+## 5. 何时升级成独立模型网关
+
+只有出现以下任一情况才重新评估 LiteLLM/Portkey：
+
+- 至少三个独立应用需要共享同一套模型 keys、预算和审计；
+- 日均请求量明显增加，需要跨部署负载均衡和集中 rate limit；
+- 必须给多人发虚拟 key 或做团队级成本控制；
+- 直接 provider SDK 的差异已经无法由 Pydantic AI 的 model profile 吸收。
+
+在此之前，进程内适配层是更小、更可靠的方案。

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from datetime import UTC
 
 from feedgen.ext.base import BaseExtension
 from feedgen.feed import FeedGenerator
-from github import Github
+from github import Auth, Github
 from marko.ext.gfm import gfm as marko
 
 from ai_daily.site_trust import is_trusted_issue
@@ -35,7 +35,7 @@ MD_HEAD = """# 甲鱼AI日报
 
 
 def login(token):
-    return Github(token)
+    return Github(auth=Auth.Token(token))
 
 
 def get_repo(user, repo_full_name):
@@ -199,8 +199,7 @@ def main(token, repo_name, issue_number=None):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("github_token", help="github_token")
     parser.add_argument("repo_name", help="repo_name (owner/repo)")
     parser.add_argument("--issue_number", help="issue_number", default=None, required=False)
     options = parser.parse_args()
-    main(options.github_token, options.repo_name, options.issue_number)
+    main(os.environ["GH_TOKEN"], options.repo_name, options.issue_number)

--- a/main.py
+++ b/main.py
@@ -1,13 +1,14 @@
-# -*- coding: utf-8 -*-
 import argparse
 import os
 import re
-from datetime import timezone
+from datetime import UTC
 
 from feedgen.ext.base import BaseExtension
 from feedgen.feed import FeedGenerator
 from github import Github
 from marko.ext.gfm import gfm as marko
+
+from ai_daily.site_trust import is_trusted_issue
 
 PRIMARY_FEED_FILENAME = "rss.xml"
 FEED_ICON_PATH = "static/icon.png"
@@ -18,7 +19,6 @@ SITE_BASE_URL = "https://wjy9902.github.io/ai-daily"
 
 TOP_ISSUES_LABELS = ["Top"]
 IGNORE_LABELS = ["Top", "TODO"]
-
 MD_HEAD = """# 甲鱼AI日报
 
 > 每日 AI 前沿技术情报，由 AI 辅助创作。内容可能存在错误，请以原始信息为准。
@@ -42,20 +42,13 @@ def get_repo(user, repo_full_name):
 
 def get_me():
     """Get repo owner from env (always available in GitHub Actions)"""
-    return (
-        os.environ.get("GITHUB_REPOSITORY_OWNER")
-        or os.environ.get("GITHUB_ACTOR")
-        or "wjy9902"
-    )
-
-
-def is_me(issue, me):
-    return issue.user.login == me
+    return os.environ.get("GITHUB_REPOSITORY_OWNER") or os.environ.get("GITHUB_ACTOR") or "wjy9902"
 
 
 def format_time(time):
     """Convert UTC datetime to Asia/Shanghai date string"""
     from datetime import timedelta
+
     cst = time + timedelta(hours=8)
     return str(cst)[:10]
 
@@ -63,20 +56,22 @@ def format_time(time):
 def add_md_header(filename):
     feed_subscribe_url = f"{SITE_BASE_URL}/{PRIMARY_FEED_FILENAME}"
     with open(filename, "w", encoding="utf-8") as f:
-        f.write(MD_HEAD.format(
-            feed_subscribe_url=feed_subscribe_url,
-            site_url=SITE_BASE_URL,
-        ))
+        f.write(
+            MD_HEAD.format(
+                feed_subscribe_url=feed_subscribe_url,
+                site_url=SITE_BASE_URL,
+            )
+        )
 
 
 def add_md_recent(repo, filename, me, limit=10):
     count = 0
     with open(filename, "a", encoding="utf-8") as f:
         for issue in repo.get_issues(state="open", sort="created", direction="desc"):
-            if not is_me(issue, me):
+            if not is_trusted_issue(issue, me):
                 continue
-            labels = [l.name for l in issue.labels]
-            if any(l in IGNORE_LABELS for l in labels):
+            labels = [label.name for label in issue.labels]
+            if any(label in IGNORE_LABELS for label in labels):
                 continue
             f.write(f"- [{issue.title}]({issue.html_url}) — {format_time(issue.created_at)}\n")
             count += 1
@@ -91,13 +86,15 @@ def add_md_top(repo, filename, me):
     with open(filename, "a", encoding="utf-8") as f:
         f.write("\n## 置顶\n\n")
         for issue in issues:
-            if is_me(issue, me):
+            if is_trusted_issue(issue, me):
                 f.write(f"- ⭐ [{issue.title}]({issue.html_url})\n")
 
 
 def add_md_footer(filename):
     with open(filename, "a", encoding="utf-8") as f:
-        f.write("\n---\n\nPowered by 🍗 鸡胸肉 | [甲鱼AI日报](https://wjy9902.github.io/ai-daily/)\n")
+        f.write(
+            "\n---\n\nPowered by 🍗 鸡胸肉 | [甲鱼AI日报](https://wjy9902.github.io/ai-daily/)\n"
+        )
 
 
 class WebfeedsExtension(BaseExtension):
@@ -120,10 +117,10 @@ def generate_rss_feed(repo, feed_filename, me):
 
     count = 0
     for issue in repo.get_issues(state="open", sort="created", direction="desc"):
-        if not is_me(issue, me):
+        if not is_trusted_issue(issue, me):
             continue
-        labels = [l.name for l in issue.labels]
-        if any(l in IGNORE_LABELS for l in labels):
+        labels = [label.name for label in issue.labels]
+        if any(label in IGNORE_LABELS for label in labels):
             continue
 
         body = issue.body or ""
@@ -134,8 +131,8 @@ def generate_rss_feed(repo, feed_filename, me):
         fe.id(issue.html_url)
         fe.title(issue.title)
         fe.link(href=f"{SITE_BASE_URL}/issue-{issue.number}/")
-        fe.published(issue.created_at.replace(tzinfo=timezone.utc))
-        fe.updated(issue.updated_at.replace(tzinfo=timezone.utc))
+        fe.published(issue.created_at.replace(tzinfo=UTC))
+        fe.updated(issue.updated_at.replace(tzinfo=UTC))
         fe.summary(summary)
         fe.content(html_body, type="html")
 
@@ -158,11 +155,15 @@ def get_to_generate_issues(repo, me, issue_number=None):
     to_generate = []
     if issue_number:
         issue = repo.get_issue(int(issue_number))
-        if is_me(issue, me) and issue.number not in existing:
+        if is_trusted_issue(issue, me) and issue.number not in existing:
             to_generate.append(issue)
     else:
         for issue in repo.get_issues(state="open", sort="created", direction="desc"):
-            if is_me(issue, me) and issue.number not in existing and not issue.pull_request:
+            if (
+                is_trusted_issue(issue, me)
+                and issue.number not in existing
+                and not issue.pull_request
+            ):
                 to_generate.append(issue)
     return to_generate
 

--- a/main.py
+++ b/main.py
@@ -15,7 +15,10 @@ FEED_ICON_PATH = "static/icon.png"
 RSS_SUMMARY_MAX_CHARS = 360
 WEBFEEDS_NS = "http://webfeeds.org/rss/1.0"
 BACKUP_DIR = "BACKUP"
-SITE_BASE_URL = "https://wjy9902.github.io/ai-daily"
+SITE_BASE_URL = os.environ.get(
+    "SITE_BASE_URL",
+    os.environ.get("BASE_URL", "https://wjy9902.github.io/ai-daily"),
+)
 
 TOP_ISSUES_LABELS = ["Top"]
 IGNORE_LABELS = ["Top", "TODO"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,66 @@
 [project]
 name = "ai-daily"
-version = "0.1.0"
-dependencies = ["PyGithub==1.59.1", "feedgen", "marko", "markdown", "lxml"]
+version = "0.2.0"
+description = "Evidence-first, fully automated AI daily digest"
+dependencies = [
+  "PyGithub>=2.6,<3",
+  "feedgen>=1,<2",
+  "feedparser>=6,<7",
+  "httpx>=0.28,<1",
+  "lxml>=5,<7",
+  "markdown>=3.7,<4",
+  "marko>=2.1,<3",
+  "pydantic-ai-slim[openai]>=1.0,<2",
+  "pydantic-settings>=2.7,<3",
+  "PyYAML>=6,<7",
+]
 requires-python = ">=3.13"
 
+[project.scripts]
+ai-daily = "ai_daily.cli:main"
+
+[dependency-groups]
+dev = [
+  "mypy>=1.15,<2",
+  "pyright>=1.1.400,<2",
+  "pytest>=8.3,<9",
+  "pytest-asyncio>=0.25,<1",
+  "respx>=0.22,<1",
+  "ruff>=0.11,<1",
+  "types-PyYAML>=6.0,<7",
+]
+
 [build-system]
-requires = ["pdm-backend"]
-build-backend = "pdm.backend"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ai_daily"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 100
+target-version = "py313"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "RUF"]
+allowed-confusables = ["，", "：", "；"]
+
+[tool.mypy]
+python_version = "3.13"
+strict = true
+packages = ["ai_daily"]
+
+[[tool.mypy.overrides]]
+module = ["feedparser"]
+ignore_missing_imports = true
+
+[tool.pyright]
+include = ["src"]
+pythonVersion = "3.13"
+typeCheckingMode = "standard"
+reportMissingTypeStubs = false

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-PyGithub==1.59.1
-feedgen
-marko
-markdown
-lxml

--- a/src/ai_daily/__init__.py
+++ b/src/ai_daily/__init__.py
@@ -1,0 +1,3 @@
+"""AI Daily generation pipeline."""
+
+__version__ = "0.2.0"

--- a/src/ai_daily/artifacts.py
+++ b/src/ai_daily/artifacts.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+
+def write_artifact(path: Path, value: BaseModel | Sequence[BaseModel] | dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload: Any
+    if isinstance(value, BaseModel):
+        payload = value.model_dump(mode="json")
+    elif isinstance(value, Sequence):
+        payload = [item.model_dump(mode="json") for item in value]
+    else:
+        payload = value
+    temporary = path.with_suffix(f"{path.suffix}.tmp")
+    temporary.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    temporary.replace(path)

--- a/src/ai_daily/assembler.py
+++ b/src/ai_daily/assembler.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from datetime import date
+
+from ai_daily.content import evidence_bundle, group_drafts
+from ai_daily.models import DraftItem, Event
+
+MARKER_VERSION = "v1"
+CATEGORY_ORDER = ["模型与平台", "前沿研究", "值得试的项目", "行业动态", "国内 AI", "快讯"]
+
+
+def marker(target_date: date) -> str:
+    return f"<!-- ai-daily:{target_date.isoformat()}:{MARKER_VERSION} -->"
+
+
+def assemble_markdown(target_date: date, drafts: list[DraftItem], events: list[Event]) -> str:
+    if not drafts:
+        raise ValueError("cannot assemble an empty digest")
+    events_by_id = {event.event_id: event for event in events}
+    grouped = group_drafts(drafts)
+    lines = [marker(target_date), f"# AI 日报 {target_date.isoformat()}", ""]
+    lines.extend(["## 速览", ""])
+    lines.extend(f"- {draft.title}" for draft in drafts)
+    lines.append("")
+    for category in CATEGORY_ORDER:
+        category_drafts = grouped.get(category, [])
+        if not category_drafts:
+            continue
+        lines.extend([f"## {category}", ""])
+        for draft in category_drafts:
+            event = events_by_id[draft.event_id]
+            bundle = evidence_bundle(event)
+            evidence_by_id = {item.evidence_id: item for item in bundle.evidence}
+            sources = " · ".join(
+                f"[{evidence_by_id[evidence_id].source}]({evidence_by_id[evidence_id].url})"
+                for evidence_id in draft.evidence_ids
+            )
+            lines.extend(
+                [
+                    f"### {draft.title}",
+                    "",
+                    f"**TL;DR：** {draft.tldr}",
+                    "",
+                    *[f"- {fact}" for fact in draft.facts],
+                    "",
+                    f"**为什么重要：** {draft.why_it_matters}",
+                    "",
+                    f"**今日行动：** {draft.action}",
+                    "",
+                    f"**来源：** {sources}",
+                ]
+            )
+            if draft.caveat:
+                lines.extend(["", f"**局限：** {draft.caveat}"])
+            lines.append("")
+    lines.extend(["---", "", "内容由自动化系统辅助整理，请以原始来源为准。", ""])
+    body = "\n".join(lines)
+    if len(body.encode("utf-8")) > 60_000:
+        raise ValueError("digest exceeds the safe GitHub Issue body limit")
+    return body

--- a/src/ai_daily/benchmark.py
+++ b/src/ai_daily/benchmark.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+
+from ai_daily.config import AppConfig, Secrets
+from ai_daily.model_gateway import ModelGateway
+from ai_daily.models import JudgeDecision, ModelsConfig, RoleModelConfig
+
+CHINESE_RE = re.compile(r"[\u4e00-\u9fff]")
+
+
+class EvalCase(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    id: str
+    title: str
+    summary: str
+    url: HttpUrl
+    expected_selected: bool
+    expected_category: str
+
+
+class PredictionRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    case_id: str
+    expected_selected: bool
+    expected_category: str
+    prediction: JudgeDecision
+    latency_ms: int = Field(ge=0)
+    cost_cny: float = Field(ge=0)
+    fallback_used: bool
+
+
+def load_dataset(path: Path) -> list[EvalCase]:
+    values = json.loads(path.read_text(encoding="utf-8"))
+    cases = [EvalCase.model_validate(value) for value in values]
+    if not 20 <= len(cases) <= 30:
+        raise ValueError("benchmark dataset must contain 20 to 30 cases")
+    return cases
+
+
+def score_records(records: list[PredictionRecord]) -> dict[str, float | int | bool]:
+    if len(records) < 20:
+        return {"cases": len(records), "score": 0, "eligible": False}
+    evidence_rate = sum(
+        record.prediction.evidence_ids == [f"{record.case_id}-1"] for record in records
+    ) / len(records)
+    selection_rate = sum(
+        record.prediction.selected == record.expected_selected
+        and record.prediction.category == record.expected_category
+        for record in records
+    ) / len(records)
+    chinese_rate = sum(
+        bool(CHINESE_RE.search(record.prediction.reason)) for record in records
+    ) / len(records)
+    average_latency = sum(record.latency_ms for record in records) / len(records)
+    total_cost = sum(record.cost_cny for record in records)
+    latency_score = 10 if average_latency <= 30_000 else 5 if average_latency <= 60_000 else 0
+    cost_score = 5 if total_cost <= 5 else 2.5 if total_cost <= 10 else 0
+    score = evidence_rate * 35 + selection_rate * 20 + 15 + chinese_rate * 15
+    score += latency_score + cost_score
+    eligible = (
+        evidence_rate == 1
+        and not any(record.fallback_used for record in records)
+        and average_latency <= 90_000
+    )
+    return {
+        "cases": len(records),
+        "evidence_rate": round(evidence_rate, 4),
+        "selection_rate": round(selection_rate, 4),
+        "chinese_rate": round(chinese_rate, 4),
+        "average_latency_ms": round(average_latency),
+        "total_cost_cny": round(total_cost, 4),
+        "score": round(score, 2),
+        "eligible": eligible,
+    }
+
+
+async def benchmark_models(dataset: Path, config: AppConfig, secrets: Secrets) -> dict[str, object]:
+    cases = load_dataset(dataset)
+    roles = config.models.roles
+    profiles = {
+        "alibaba-judge": (roles["judge"].primary, roles["judge"].fallback),
+        "deepseek-judge": (roles["judge"].fallback, roles["judge"].primary),
+        "alibaba-editor": (roles["editor"].primary, roles["editor"].fallback),
+        "deepseek-editor": (roles["editor"].fallback, roles["editor"].primary),
+    }
+    results: dict[str, object] = {}
+    ranked: list[tuple[str, float]] = []
+    for profile, (primary, fallback) in profiles.items():
+        role_config = RoleModelConfig(primary=primary, fallback=fallback)
+        model_config = ModelsConfig(
+            budget=config.models.budget,
+            roles={"judge": role_config, "editor": role_config},
+        )
+        gateway = ModelGateway(model_config, secrets)
+        records: list[PredictionRecord] = []
+        for case in cases:
+            before_runs = len(gateway.runs)
+            prediction = await gateway.generate(
+                "judge",
+                JudgeDecision,
+                instructions=(
+                    "判断一条候选是否应进入中文 AI 日报。只使用给定证据，reason 使用中文，"
+                    "evidence_ids 必须原样返回。"
+                ),
+                prompt=json.dumps(
+                    {
+                        "event_id": case.id,
+                        "title": case.title,
+                        "summary": case.summary,
+                        "evidence": [{"evidence_id": f"{case.id}-1", "url": str(case.url)}],
+                    },
+                    ensure_ascii=False,
+                ),
+            )
+            new_runs = gateway.runs[before_runs:]
+            successful = next(run for run in reversed(new_runs) if run.status == "ok")
+            records.append(
+                PredictionRecord(
+                    case_id=case.id,
+                    expected_selected=case.expected_selected,
+                    expected_category=case.expected_category,
+                    prediction=prediction,
+                    latency_ms=successful.latency_ms,
+                    cost_cny=successful.cost_cny or 0,
+                    fallback_used=successful.actual_model != primary.model,
+                )
+            )
+        metrics = score_records(records)
+        results[profile] = {
+            "primary": f"{primary.provider}:{primary.model}",
+            "metrics": metrics,
+            "records": [record.model_dump(mode="json") for record in records],
+        }
+        if metrics["eligible"] is True:
+            ranked.append((profile, float(metrics["score"])))
+    ranked.sort(key=lambda item: item[1], reverse=True)
+    recommendation = "keep-current"
+    if len(ranked) >= 2 and ranked[0][1] - ranked[1][1] >= 5:
+        recommendation = ranked[0][0]
+    return {"profiles": results, "recommendation": recommendation}

--- a/src/ai_daily/budget.py
+++ b/src/ai_daily/budget.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ai_daily.models import BudgetConfig, ModelRun
+
+
+class BudgetExceeded(RuntimeError):
+    pass
+
+
+@dataclass
+class BudgetLedger:
+    config: BudgetConfig
+    requests: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cost_cny: float = 0
+
+    def reserve_request(self) -> None:
+        if self.requests + 1 > self.config.request_limit:
+            raise BudgetExceeded("model request limit exceeded")
+        self.requests += 1
+
+    def reconcile_requests(self, actual_requests: int) -> None:
+        additional = max(0, actual_requests - 1)
+        if self.requests + additional > self.config.request_limit:
+            raise BudgetExceeded("model request limit exceeded")
+        self.requests += additional
+
+    def record(self, run: ModelRun) -> None:
+        next_input = self.input_tokens + run.input_tokens
+        next_output = self.output_tokens + run.output_tokens
+        next_cost = self.cost_cny + (run.cost_cny or 0)
+        if next_input > self.config.input_token_limit:
+            raise BudgetExceeded("input token limit exceeded")
+        if next_output > self.config.output_token_limit:
+            raise BudgetExceeded("output token limit exceeded")
+        if next_cost > self.config.cost_cny_limit:
+            raise BudgetExceeded("cost limit exceeded")
+        self.input_tokens = next_input
+        self.output_tokens = next_output
+        self.cost_cny = next_cost

--- a/src/ai_daily/cli.py
+++ b/src/ai_daily/cli.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from datetime import date, datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import httpx
+
+from ai_daily.benchmark import benchmark_models
+from ai_daily.config import Secrets, load_config
+from ai_daily.pipeline import DailyPipeline
+from ai_daily.publisher import GitHubPublisher
+from ai_daily.verifier import verify_publication
+
+
+def _target_date(value: str | None) -> date:
+    return date.fromisoformat(value) if value else datetime.now(ZoneInfo("Asia/Shanghai")).date()
+
+
+async def _run(args: argparse.Namespace) -> int:
+    config = load_config(Path(args.config_dir))
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        artifact, _ = await DailyPipeline(config, Secrets(), client=client).run(
+            _target_date(args.date), publish=args.mode == "publish"
+        )
+    if artifact.publication is None:
+        raise RuntimeError("pipeline did not produce a publication record")
+    print(json.dumps(artifact.publication.model_dump(mode="json"), ensure_ascii=False))
+    return 0
+
+
+async def _verify(args: argparse.Namespace) -> int:
+    config = load_config(Path(args.config_dir))
+    secrets = Secrets()
+    if not secrets.github_token:
+        raise RuntimeError("GITHUB_TOKEN is required")
+    target = _target_date(args.date)
+    repository = secrets.github_repository or config.pipeline.repository
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        publisher = GitHubPublisher(repository, secrets.github_token, client)
+        publication = await publisher.find_publication(target)
+        if not publication or publication.issue_number is None:
+            raise RuntimeError("daily issue does not exist")
+        verified = await verify_publication(
+            target,
+            str(secrets.site_base_url or config.pipeline.site_base_url),
+            publication.issue_number,
+            client,
+        )
+    print(verified.model_dump_json())
+    return 0
+
+
+async def _rebuild(args: argparse.Namespace) -> int:
+    config = load_config(Path(args.config_dir))
+    secrets = Secrets()
+    if not secrets.github_token:
+        raise RuntimeError("GITHUB_TOKEN is required")
+    async with httpx.AsyncClient() as client:
+        repository = secrets.github_repository or config.pipeline.repository
+        response = await client.post(
+            f"https://api.github.com/repos/{repository}/actions/workflows/generate_site.yml/dispatches",
+            headers={
+                "Authorization": f"Bearer {secrets.github_token}",
+                "Accept": "application/vnd.github+json",
+            },
+            json={"ref": "main"},
+            timeout=20,
+        )
+        response.raise_for_status()
+    print(json.dumps({"status": "dispatched", "date": _target_date(args.date).isoformat()}))
+    return 0
+
+
+async def _issue_exists(args: argparse.Namespace) -> int:
+    config = load_config(Path(args.config_dir))
+    secrets = Secrets()
+    if not secrets.github_token:
+        raise RuntimeError("GITHUB_TOKEN is required")
+    repository = secrets.github_repository or config.pipeline.repository
+    async with httpx.AsyncClient() as client:
+        publication = await GitHubPublisher(
+            repository, secrets.github_token, client
+        ).find_publication(_target_date(args.date))
+    if publication is None:
+        return 1
+    print(publication.model_dump_json())
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="ai-daily")
+    parser.add_argument("--config-dir", default="config")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    run = subparsers.add_parser("run")
+    run.add_argument("--date")
+    run.add_argument("--mode", choices=("dry-run", "publish"), required=True)
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--date")
+    rebuild = subparsers.add_parser("rebuild-site")
+    rebuild.add_argument("--date")
+    issue_exists = subparsers.add_parser("issue-exists")
+    issue_exists.add_argument("--date")
+    benchmark = subparsers.add_parser("benchmark-models")
+    benchmark.add_argument("--dataset", type=Path, required=True)
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.command == "run":
+        code = asyncio.run(_run(args))
+    elif args.command == "verify":
+        code = asyncio.run(_verify(args))
+    elif args.command == "rebuild-site":
+        code = asyncio.run(_rebuild(args))
+    elif args.command == "issue-exists":
+        code = asyncio.run(_issue_exists(args))
+    else:
+        config = load_config(Path(args.config_dir))
+        result = asyncio.run(benchmark_models(args.dataset, config, Secrets()))
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        code = 0
+    raise SystemExit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ai_daily/config.py
+++ b/src/ai_daily/config.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from ai_daily.models import ModelsConfig, PipelineConfig, SourceConfig
+
+
+class SourcesDocument(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    sources: list[SourceConfig]
+
+
+class Secrets(BaseSettings):
+    model_config = SettingsConfigDict(env_file=None, extra="ignore")
+
+    dashscope_api_key: str | None = None
+    dashscope_base_url: str | None = None
+    deepseek_api_key: str | None = None
+    github_token: str | None = None
+    github_repository: str | None = None
+    site_base_url: str | None = None
+
+
+class AppConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    pipeline: PipelineConfig
+    models: ModelsConfig
+    sources: list[SourceConfig]
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        value = yaml.safe_load(handle)
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a YAML mapping")
+    return value
+
+
+def load_config(config_dir: Path = Path("config")) -> AppConfig:
+    pipeline = PipelineConfig.model_validate(_read_yaml(config_dir / "pipeline.yaml"))
+    models = ModelsConfig.model_validate(_read_yaml(config_dir / "models.yaml"))
+    sources = SourcesDocument.model_validate(_read_yaml(config_dir / "sources.yaml"))
+    return AppConfig(pipeline=pipeline, models=models, sources=sources.sources)

--- a/src/ai_daily/content.py
+++ b/src/ai_daily/content.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+
+from pydantic import RootModel
+
+from ai_daily.model_gateway import ModelGateway
+from ai_daily.models import DraftItem, Event, Evidence, EvidenceBundle, JudgeDecision
+
+
+class JudgeBatch(RootModel[list[JudgeDecision]]):
+    pass
+
+
+def evidence_bundle(event: Event) -> EvidenceBundle:
+    evidence = [
+        Evidence(
+            evidence_id=f"{event.event_id}-{index}",
+            url=item.url,
+            title=item.title,
+            excerpt=(item.summary or item.title)[:4000],
+            source=item.source,
+        )
+        for index, item in enumerate(event.items[:3], start=1)
+    ]
+    return EvidenceBundle(event_id=event.event_id, evidence=evidence)
+
+
+async def judge_events(gateway: ModelGateway, events: list[Event]) -> list[JudgeDecision]:
+    bundles = [evidence_bundle(event).model_dump(mode="json") for event in events]
+    result = await gateway.generate(
+        "judge",
+        JudgeBatch,
+        instructions=(
+            "你是中文 AI 日报的选题编辑。只依据输入证据判断，不补充外部事实。"
+            "每个 event_id 必须恰好返回一个决定，evidence_ids 只能使用输入值。"
+            "优先会改变技术或产品行动的官方发布、重要研究和高质量开源项目。"
+        ),
+        prompt=json.dumps(bundles, ensure_ascii=False),
+    )
+    by_event = {decision.event_id: decision for decision in result.root}
+    expected = {event.event_id for event in events}
+    if set(by_event) != expected or len(result.root) != len(events):
+        raise ValueError("judge output does not cover every event exactly once")
+    allowed = {
+        bundle.event_id: {evidence.evidence_id for evidence in bundle.evidence}
+        for bundle in map(evidence_bundle, events)
+    }
+    for decision in result.root:
+        if not set(decision.evidence_ids) <= allowed[decision.event_id]:
+            raise ValueError("judge referenced unknown evidence")
+    return result.root
+
+
+async def draft_selected(
+    gateway: ModelGateway,
+    events: list[Event],
+    decisions: list[JudgeDecision],
+    selected_min: int,
+    selected_max: int,
+) -> list[DraftItem]:
+    selected_decisions = sorted(
+        (decision for decision in decisions if decision.selected),
+        key=lambda value: (value.relevance, value.confidence),
+        reverse=True,
+    )[:selected_max]
+    if len(selected_decisions) < selected_min:
+        raise ValueError(f"only {len(selected_decisions)} events passed the selection gate")
+    events_by_id = {event.event_id: event for event in events}
+    drafts = []
+    for decision in selected_decisions:
+        bundle = evidence_bundle(events_by_id[decision.event_id])
+        draft = await gateway.generate(
+            "editor",
+            DraftItem,
+            instructions=(
+                "你是事实优先的中文技术编辑。只能使用证据包中的事实和 evidence_id。"
+                "不要把推测写成事实；信息不足时写入 caveat。action 必须具体、克制。"
+            ),
+            prompt=json.dumps(
+                {"decision": decision.model_dump(), "bundle": bundle.model_dump(mode="json")},
+                ensure_ascii=False,
+            ),
+        )
+        if draft.event_id != decision.event_id:
+            raise ValueError("editor changed event_id")
+        allowed = {evidence.evidence_id for evidence in bundle.evidence}
+        if not set(draft.evidence_ids) <= allowed:
+            raise ValueError("editor referenced unknown evidence")
+        drafts.append(draft)
+    return drafts
+
+
+def group_drafts(drafts: list[DraftItem]) -> dict[str, list[DraftItem]]:
+    grouped: dict[str, list[DraftItem]] = defaultdict(list)
+    for draft in drafts:
+        grouped[draft.category].append(draft)
+    return dict(grouped)

--- a/src/ai_daily/history.py
+++ b/src/ai_daily/history.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta
+
+import httpx
+
+URL_RE = re.compile(r'https?://[^\s)>"\]]+')
+
+
+async def fetch_historical_urls(
+    client: httpx.AsyncClient,
+    repository: str,
+    token: str | None,
+    days: int,
+) -> set[str]:
+    since = (datetime.now(UTC) - timedelta(days=days)).isoformat()
+    headers = {"Accept": "application/vnd.github+json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    response = await client.get(
+        f"https://api.github.com/repos/{repository}/issues",
+        headers=headers,
+        params={"state": "all", "since": since, "per_page": 100},
+        timeout=20,
+    )
+    response.raise_for_status()
+    urls: set[str] = set()
+    for issue in response.json():
+        if "pull_request" in issue:
+            continue
+        urls.update(URL_RE.findall(issue.get("body") or ""))
+    return urls

--- a/src/ai_daily/model_gateway.py
+++ b/src/ai_daily/model_gateway.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Literal, TypeVar
+
+import httpx
+from pydantic import BaseModel
+from pydantic_ai import Agent, ModelSettings
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, UsageLimitExceeded
+from pydantic_ai.models.openai import OpenAIChatModel
+from pydantic_ai.providers.alibaba import AlibabaProvider
+from pydantic_ai.providers.deepseek import DeepSeekProvider
+from pydantic_ai.usage import UsageLimits
+
+from ai_daily.budget import BudgetLedger
+from ai_daily.config import Secrets
+from ai_daily.models import ModelEndpoint, ModelRun, ModelsConfig
+
+OutputT = TypeVar("OutputT", bound=BaseModel)
+
+
+class MissingProviderSecret(RuntimeError):
+    pass
+
+
+class ModelInvocationFailed(RuntimeError):
+    pass
+
+
+def is_recoverable(error: Exception) -> bool:
+    if isinstance(error, (httpx.TimeoutException, httpx.ConnectError)):
+        return True
+    if isinstance(error, ModelHTTPError):
+        return error.status_code == 429 or 500 <= error.status_code < 600
+    return False
+
+
+class ModelGateway:
+    def __init__(
+        self,
+        config: ModelsConfig,
+        secrets: Secrets | None = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.config = config
+        self.secrets = secrets or Secrets()
+        self.ledger = BudgetLedger(config.budget)
+        self.runs: list[ModelRun] = []
+        self.clock = clock
+
+    async def generate(
+        self,
+        role: Literal["judge", "editor"],
+        output_type: type[OutputT],
+        instructions: str,
+        prompt: str,
+    ) -> OutputT:
+        role_config = self.config.roles[role]
+        fallback_reason: str | None = None
+        for attempt, endpoint in enumerate((role_config.primary, role_config.fallback), start=1):
+            self.ledger.reserve_request()
+            started = self.clock()
+            try:
+                model = self._build_model(endpoint)
+                agent: Agent[None, OutputT] = Agent(
+                    model,
+                    output_type=output_type,
+                    instructions=instructions,
+                    retries=0,
+                )
+                result = await agent.run(
+                    prompt,
+                    model_settings=ModelSettings(
+                        temperature=endpoint.temperature,
+                        max_tokens=endpoint.max_output_tokens,
+                        timeout=endpoint.timeout_seconds,
+                    ),
+                    usage_limits=UsageLimits(
+                        request_limit=1,
+                        input_tokens_limit=self.config.budget.input_token_limit,
+                        output_tokens_limit=self.config.budget.output_token_limit,
+                    ),
+                )
+                usage = result.usage()
+                self.ledger.reconcile_requests(usage.requests)
+                run = self._success_run(
+                    role,
+                    role_config.primary,
+                    endpoint,
+                    attempt,
+                    fallback_reason,
+                    started,
+                    usage.input_tokens,
+                    usage.output_tokens,
+                )
+                self.runs.append(run)
+                self.ledger.record(run)
+                return result.output
+            except (UsageLimitExceeded, MissingProviderSecret):
+                raise
+            except Exception as error:
+                run = self._failed_run(
+                    role,
+                    role_config.primary,
+                    endpoint,
+                    attempt,
+                    fallback_reason,
+                    started,
+                    error,
+                )
+                self.runs.append(run)
+                if attempt == 1 and is_recoverable(error):
+                    fallback_reason = self._safe_error(error)
+                    continue
+                raise ModelInvocationFailed(self._safe_error(error)) from error
+        raise AssertionError("unreachable")
+
+    def _build_model(self, endpoint: ModelEndpoint) -> OpenAIChatModel:
+        if endpoint.provider == "alibaba":
+            key = self.secrets.dashscope_api_key
+            base_url = self.secrets.dashscope_base_url
+            if not key or not base_url:
+                raise MissingProviderSecret("DASHSCOPE_API_KEY and DASHSCOPE_BASE_URL are required")
+            alibaba_provider = AlibabaProvider(api_key=key, base_url=base_url)
+            return OpenAIChatModel(endpoint.model, provider=alibaba_provider)
+        elif endpoint.provider == "deepseek":
+            if not self.secrets.deepseek_api_key:
+                raise MissingProviderSecret("DEEPSEEK_API_KEY is required")
+            deepseek_provider = DeepSeekProvider(api_key=self.secrets.deepseek_api_key)
+            return OpenAIChatModel(endpoint.model, provider=deepseek_provider)
+        else:
+            raise MissingProviderSecret("Ollama is local-only and must use a separate profile")
+
+    def _success_run(
+        self,
+        role: Literal["judge", "editor"],
+        requested: ModelEndpoint,
+        endpoint: ModelEndpoint,
+        attempt: int,
+        fallback_reason: str | None,
+        started: float,
+        input_tokens: int,
+        output_tokens: int,
+    ) -> ModelRun:
+        cost = (
+            input_tokens * endpoint.input_cost_cny_per_million
+            + output_tokens * endpoint.output_cost_cny_per_million
+        ) / 1_000_000
+        return ModelRun(
+            role=role,
+            requested_provider=requested.provider,
+            requested_model=requested.model,
+            actual_provider=endpoint.provider,
+            actual_model=endpoint.model,
+            attempt=attempt,
+            status="ok",
+            fallback_reason=fallback_reason,
+            latency_ms=int((self.clock() - started) * 1000),
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_cny=cost,
+        )
+
+    def _failed_run(
+        self,
+        role: Literal["judge", "editor"],
+        requested: ModelEndpoint,
+        endpoint: ModelEndpoint,
+        attempt: int,
+        fallback_reason: str | None,
+        started: float,
+        error: Exception,
+    ) -> ModelRun:
+        return ModelRun(
+            role=role,
+            requested_provider=requested.provider,
+            requested_model=requested.model,
+            actual_provider=endpoint.provider,
+            actual_model=endpoint.model,
+            attempt=attempt,
+            status="failed",
+            fallback_reason=fallback_reason,
+            latency_ms=int((self.clock() - started) * 1000),
+            input_tokens=0,
+            output_tokens=0,
+            error_type=type(error).__name__,
+        )
+
+    @staticmethod
+    def _safe_error(error: Exception) -> str:
+        if isinstance(error, ModelHTTPError):
+            return f"ModelHTTPError:{error.status_code}"
+        if isinstance(error, ModelAPIError):
+            return type(error).__name__
+        return type(error).__name__

--- a/src/ai_daily/models.py
+++ b/src/ai_daily/models.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import StrEnum
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, model_validator
+
+type Category = Literal["模型与平台", "前沿研究", "值得试的项目", "行业动态", "国内 AI", "快讯"]
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class SourceTier(StrEnum):
+    A = "A"
+    B = "B"
+    C = "C"
+
+
+class SourceConfig(StrictModel):
+    name: str = Field(pattern=r"^[a-z0-9][a-z0-9-]+$")
+    kind: Literal["rss", "hackernews", "github_releases", "arxiv", "huggingface", "html"]
+    url: HttpUrl
+    tier: SourceTier
+    enabled: bool = True
+    limit: int = Field(default=30, ge=1, le=100)
+    timeout_seconds: float = Field(default=20, gt=0, le=60)
+
+
+class RawItem(StrictModel):
+    source: str
+    source_tier: SourceTier
+    source_item_id: str
+    url: HttpUrl
+    title: str = Field(min_length=1, max_length=500)
+    summary: str = Field(default="", max_length=10000)
+    published_at: datetime | None = None
+    discovered_at: datetime
+    author: str | None = None
+    metrics: dict[str, int | float | str] = Field(default_factory=dict)
+
+
+class SourceHealth(StrictModel):
+    source: str
+    tier: SourceTier
+    status: Literal["ok", "not_modified", "failed"]
+    item_count: int = Field(ge=0)
+    latency_ms: int = Field(ge=0)
+    error: str | None = None
+
+
+class Event(StrictModel):
+    event_id: str
+    canonical_url: HttpUrl
+    title: str
+    summary: str
+    published_at: datetime | None = None
+    items: list[RawItem] = Field(min_length=1)
+    score: float = Field(default=0, ge=0, le=100)
+
+
+class Evidence(StrictModel):
+    evidence_id: str
+    url: HttpUrl
+    title: str
+    excerpt: str = Field(max_length=4000)
+    source: str
+
+
+class EvidenceBundle(StrictModel):
+    event_id: str
+    evidence: list[Evidence] = Field(min_length=1)
+
+
+class JudgeDecision(StrictModel):
+    event_id: str
+    selected: bool
+    category: Category
+    relevance: int = Field(ge=0, le=100)
+    confidence: float = Field(ge=0, le=1)
+    reason: str = Field(min_length=1, max_length=600)
+    evidence_ids: list[str] = Field(min_length=1)
+
+
+class DraftItem(StrictModel):
+    event_id: str
+    category: Category
+    title: str = Field(min_length=1, max_length=120)
+    tldr: str = Field(min_length=1, max_length=300)
+    facts: list[Annotated[str, Field(min_length=1, max_length=500)]] = Field(
+        min_length=1, max_length=5
+    )
+    why_it_matters: str = Field(min_length=1, max_length=800)
+    action: str = Field(min_length=1, max_length=500)
+    caveat: str | None = Field(default=None, max_length=500)
+    evidence_ids: list[str] = Field(min_length=1)
+
+
+class ModelRun(StrictModel):
+    role: Literal["judge", "editor"]
+    requested_provider: str
+    requested_model: str
+    actual_provider: str
+    actual_model: str
+    attempt: int = Field(ge=1)
+    status: Literal["ok", "failed"]
+    fallback_reason: str | None = None
+    latency_ms: int = Field(ge=0)
+    input_tokens: int = Field(ge=0)
+    output_tokens: int = Field(ge=0)
+    cost_cny: float | None = Field(default=None, ge=0)
+    error_type: str | None = None
+
+
+class Publication(StrictModel):
+    target_date: date
+    issue_number: int | None = None
+    issue_url: HttpUrl | None = None
+    page_url: HttpUrl | None = None
+    rss_url: HttpUrl | None = None
+    status: Literal["dry_run", "issue_published", "verified", "failed"]
+    marker: str
+
+
+class ModelEndpoint(StrictModel):
+    provider: Literal["alibaba", "deepseek", "ollama"]
+    model: str
+    timeout_seconds: float = Field(gt=0, le=180)
+    max_output_tokens: int = Field(gt=0, le=30000)
+    temperature: float = Field(ge=0, lt=2)
+    input_cost_cny_per_million: float = Field(ge=0)
+    output_cost_cny_per_million: float = Field(ge=0)
+
+
+class RoleModelConfig(StrictModel):
+    primary: ModelEndpoint
+    fallback: ModelEndpoint
+
+    @model_validator(mode="after")
+    def require_cross_provider_fallback(self) -> RoleModelConfig:
+        if self.primary.provider == self.fallback.provider:
+            raise ValueError("fallback must use a different provider")
+        if self.fallback.provider == "ollama":
+            raise ValueError("Ollama cannot be a production fallback")
+        return self
+
+
+class BudgetConfig(StrictModel):
+    request_limit: int = Field(gt=0, le=100)
+    input_token_limit: int = Field(gt=0)
+    output_token_limit: int = Field(gt=0)
+    cost_cny_limit: float = Field(gt=0)
+
+
+class ModelsConfig(StrictModel):
+    budget: BudgetConfig
+    roles: dict[Literal["judge", "editor"], RoleModelConfig]
+
+
+class PipelineConfig(StrictModel):
+    timezone: str
+    site_base_url: HttpUrl
+    repository: str = Field(pattern=r"^[^/]+/[^/]+$")
+    artifacts_dir: str
+    candidate_limit: int = Field(ge=1, le=60)
+    selected_min: int = Field(ge=1)
+    selected_max: int = Field(ge=1, le=20)
+    tier_a_min_coverage: float = Field(ge=0, le=1)
+    collection_window_hours: int = Field(gt=0, le=72)
+    cluster_window_hours: int = Field(gt=0, le=96)
+    history_window_days: int = Field(gt=0, le=90)
+
+    @model_validator(mode="after")
+    def validate_selection_range(self) -> PipelineConfig:
+        if self.selected_min > self.selected_max:
+            raise ValueError("selected_min cannot exceed selected_max")
+        return self
+
+
+class RunArtifact(StrictModel):
+    run_id: str
+    target_date: date
+    items: list[RawItem]
+    health: list[SourceHealth]
+    events: list[Event]
+    model_runs: list[ModelRun]
+    publication: Publication | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/src/ai_daily/normalize.py
+++ b/src/ai_daily/normalize.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from collections import defaultdict
+from datetime import datetime, timedelta
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+from pydantic import HttpUrl
+
+from ai_daily.models import Event, RawItem
+
+TRACKING_PARAMS = {
+    "fbclid",
+    "gclid",
+    "mc_cid",
+    "mc_eid",
+    "ref",
+    "source",
+}
+TOKEN_RE = re.compile(r"[a-z0-9][a-z0-9.+-]{1,}|[\u4e00-\u9fff]{2,}", re.IGNORECASE)
+
+
+def canonicalize_url(value: str) -> str:
+    parts = urlsplit(value.strip())
+    host = (parts.hostname or "").lower()
+    if host.startswith("www."):
+        host = host[4:]
+    port = parts.port
+    netloc = host if port is None else f"{host}:{port}"
+    path = re.sub(r"/{2,}", "/", parts.path or "/")
+    if path != "/":
+        path = path.rstrip("/")
+    query = [
+        (key, value)
+        for key, value in parse_qsl(parts.query, keep_blank_values=True)
+        if not key.lower().startswith("utm_") and key.lower() not in TRACKING_PARAMS
+    ]
+    return urlunsplit((parts.scheme.lower() or "https", netloc, path, urlencode(query), ""))
+
+
+def title_tokens(title: str) -> set[str]:
+    return {token.lower() for token in TOKEN_RE.findall(title)}
+
+
+def _similar(left: RawItem, right: RawItem, window: timedelta) -> bool:
+    left_time = left.published_at or left.discovered_at
+    right_time = right.published_at or right.discovered_at
+    if abs(left_time - right_time) > window:
+        return False
+    left_tokens = title_tokens(left.title)
+    right_tokens = title_tokens(right.title)
+    if not left_tokens or not right_tokens:
+        return False
+    overlap = len(left_tokens & right_tokens) / len(left_tokens | right_tokens)
+    return overlap >= 0.72
+
+
+def cluster_items(items: list[RawItem], window_hours: int = 48) -> list[Event]:
+    by_url: dict[str, list[RawItem]] = defaultdict(list)
+    for item in items:
+        by_url[canonicalize_url(str(item.url))].append(item)
+
+    groups: list[list[RawItem]] = list(by_url.values())
+    merged: list[list[RawItem]] = []
+    window = timedelta(hours=window_hours)
+    for group in groups:
+        for existing in merged:
+            if _similar(group[0], existing[0], window):
+                existing.extend(group)
+                break
+        else:
+            merged.append(group)
+
+    events = []
+    for group in merged:
+        primary = min(group, key=lambda item: (item.source_tier.value, -len(item.summary)))
+        canonical = canonicalize_url(str(primary.url))
+        event_id = hashlib.sha256(canonical.encode()).hexdigest()[:16]
+        events.append(
+            Event(
+                event_id=event_id,
+                canonical_url=HttpUrl(canonical),
+                title=primary.title,
+                summary=primary.summary,
+                published_at=primary.published_at,
+                items=group,
+            )
+        )
+    return events
+
+
+def score_events(events: list[Event], now: datetime) -> list[Event]:
+    scored = []
+    for event in events:
+        tiers = {item.source_tier.value for item in event.items}
+        source_score = 30 if "A" in tiers else 20 if "B" in tiers else 10
+        age = now - (event.published_at or event.items[0].discovered_at)
+        recency = max(0, 25 - age.total_seconds() / 3600)
+        corroboration = min(20, (len({item.source for item in event.items}) - 1) * 10)
+        text = f"{event.title} {event.summary}".lower()
+        action_terms = ("release", "launch", "api", "model", "open source", "发布", "开源", "模型")
+        actionability = 15 if any(term in text for term in action_terms) else 5
+        metrics = sum(
+            float(value)
+            for item in event.items
+            for value in item.metrics.values()
+            if isinstance(value, (int, float))
+        )
+        popularity = min(10, metrics / 50)
+        scored.append(
+            event.model_copy(
+                update={
+                    "score": min(
+                        100, source_score + recency + corroboration + actionability + popularity
+                    )
+                }
+            )
+        )
+    return sorted(scored, key=lambda event: event.score, reverse=True)
+
+
+def remove_historical(events: list[Event], historical_urls: set[str]) -> list[Event]:
+    canonical_history = {canonicalize_url(url) for url in historical_urls}
+    return [
+        event
+        for event in events
+        if canonicalize_url(str(event.canonical_url)) not in canonical_history
+    ]

--- a/src/ai_daily/pipeline.py
+++ b/src/ai_daily/pipeline.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import httpx
+
+from ai_daily.artifacts import write_artifact
+from ai_daily.assembler import assemble_markdown, marker
+from ai_daily.config import AppConfig, Secrets
+from ai_daily.content import draft_selected, judge_events
+from ai_daily.history import fetch_historical_urls
+from ai_daily.model_gateway import ModelGateway
+from ai_daily.models import Publication, RunArtifact, SourceHealth, SourceTier
+from ai_daily.normalize import cluster_items, remove_historical, score_events
+from ai_daily.publisher import GitHubPublisher
+from ai_daily.sources import Collector
+
+
+class QualityGateFailed(RuntimeError):
+    pass
+
+
+def collection_window(
+    target_date: date,
+    timezone_name: str,
+    window_hours: int,
+    now: datetime | None = None,
+) -> tuple[datetime, datetime]:
+    local_timezone = ZoneInfo(timezone_name)
+    run_time = now.astimezone(local_timezone) if now else datetime.now(local_timezone)
+    if run_time.date() != target_date:
+        run_time = datetime.combine(target_date, run_time.timetz())
+    return run_time - timedelta(hours=window_hours), run_time
+
+
+class DailyPipeline:
+    def __init__(
+        self,
+        config: AppConfig,
+        secrets: Secrets | None = None,
+        client: httpx.AsyncClient | None = None,
+        collector: Collector | None = None,
+        gateway: ModelGateway | None = None,
+    ) -> None:
+        self.config = config
+        self.secrets = secrets or Secrets()
+        self.client = client or httpx.AsyncClient(follow_redirects=True)
+        self.collector = collector or Collector(self.client)
+        self.gateway = gateway or ModelGateway(config.models, self.secrets)
+
+    async def run(self, target_date: date, publish: bool) -> tuple[RunArtifact, str]:
+        run_id = f"{target_date.isoformat()}-{uuid.uuid4().hex[:8]}"
+        run_dir = Path(self.config.pipeline.artifacts_dir) / target_date.isoformat() / run_id
+        repository = self.secrets.github_repository or self.config.pipeline.repository
+        items, health = await self.collector.collect(self.config.sources)
+        write_artifact(
+            run_dir / "sources.json",
+            {
+                "items": [item.model_dump(mode="json") for item in items],
+                "health": [item.model_dump(mode="json") for item in health],
+            },
+        )
+        self._check_source_health(health)
+        timezone = ZoneInfo(self.config.pipeline.timezone)
+        cutoff, run_time = collection_window(
+            target_date,
+            self.config.pipeline.timezone,
+            self.config.pipeline.collection_window_hours,
+        )
+        filtered = [
+            item
+            for item in items
+            if cutoff
+            <= (item.published_at or item.discovered_at).astimezone(timezone)
+            <= run_time + timedelta(minutes=5)
+        ]
+        events = score_events(
+            cluster_items(filtered, self.config.pipeline.cluster_window_hours), datetime.now(UTC)
+        )
+        historical_urls = await fetch_historical_urls(
+            self.client,
+            repository,
+            self.secrets.github_token,
+            self.config.pipeline.history_window_days,
+        )
+        candidates = remove_historical(events, historical_urls)[
+            : self.config.pipeline.candidate_limit
+        ]
+        write_artifact(run_dir / "candidates.json", candidates)
+        if len(candidates) < self.config.pipeline.selected_min:
+            raise QualityGateFailed(f"only {len(candidates)} candidates remain after deduplication")
+        try:
+            decisions = await judge_events(self.gateway, candidates)
+            write_artifact(run_dir / "decisions.json", decisions)
+            drafts = await draft_selected(
+                self.gateway,
+                candidates,
+                decisions,
+                self.config.pipeline.selected_min,
+                self.config.pipeline.selected_max,
+            )
+        finally:
+            write_artifact(run_dir / "model-runs.json", self.gateway.runs)
+        body = assemble_markdown(target_date, drafts, candidates)
+        publication = Publication(
+            target_date=target_date,
+            status="dry_run",
+            marker=marker(target_date),
+        )
+        if publish:
+            if not self.secrets.github_token:
+                raise QualityGateFailed("GITHUB_TOKEN is required in publish mode")
+            publisher = GitHubPublisher(repository, self.secrets.github_token, self.client)
+            publication = await publisher.publish(target_date, body)
+        artifact = RunArtifact(
+            run_id=run_id,
+            target_date=target_date,
+            items=filtered,
+            health=health,
+            events=candidates,
+            model_runs=self.gateway.runs,
+            publication=publication,
+            metadata={
+                "candidate_count": len(candidates),
+                "selected_count": len(drafts),
+                "model_requests": self.gateway.ledger.requests,
+                "input_tokens": self.gateway.ledger.input_tokens,
+                "output_tokens": self.gateway.ledger.output_tokens,
+                "cost_cny": round(self.gateway.ledger.cost_cny, 6),
+            },
+        )
+        write_artifact(run_dir / "run.json", artifact)
+        (run_dir / "digest.md").write_text(body, encoding="utf-8")
+        return artifact, body
+
+    def _check_source_health(self, health: Sequence[SourceHealth]) -> None:
+        tier_a = [item for item in health if item.tier == SourceTier.A]
+        if not tier_a:
+            raise QualityGateFailed("no Tier A sources are configured")
+        successful = sum(item.status in {"ok", "not_modified"} for item in tier_a)
+        coverage = successful / len(tier_a)
+        if coverage < self.config.pipeline.tier_a_min_coverage:
+            raise QualityGateFailed(f"Tier A source coverage is {coverage:.0%}")

--- a/src/ai_daily/publisher.py
+++ b/src/ai_daily/publisher.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import httpx
+from pydantic import HttpUrl
+
+from ai_daily.assembler import marker
+from ai_daily.models import Publication
+
+
+class GitHubPublisher:
+    def __init__(
+        self, repository: str, token: str, client: httpx.AsyncClient | None = None
+    ) -> None:
+        self.repository = repository
+        self.client = client or httpx.AsyncClient()
+        self.headers = {
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+
+    async def publish(self, target_date: date, body: str) -> Publication:
+        expected_marker = marker(target_date)
+        if expected_marker not in body:
+            raise ValueError("publication body is missing its machine marker")
+        await self._ensure_daily_label()
+        issue = await self._find(target_date, expected_marker)
+        payload = {"title": target_date.isoformat(), "body": body, "labels": ["Daily"]}
+        if issue:
+            response = await self.client.patch(
+                str(issue["url"]), headers=self.headers, json=payload, timeout=20
+            )
+        else:
+            response = await self.client.post(
+                f"https://api.github.com/repos/{self.repository}/issues",
+                headers=self.headers,
+                json=payload,
+                timeout=20,
+            )
+        response.raise_for_status()
+        value = response.json()
+        return Publication(
+            target_date=target_date,
+            issue_number=value["number"],
+            issue_url=HttpUrl(str(value["html_url"])),
+            status="issue_published",
+            marker=expected_marker,
+        )
+
+    async def _ensure_daily_label(self) -> None:
+        label_url = f"https://api.github.com/repos/{self.repository}/labels/Daily"
+        response = await self.client.get(label_url, headers=self.headers, timeout=20)
+        if response.status_code == 200:
+            return
+        if response.status_code != 404:
+            response.raise_for_status()
+        created = await self.client.post(
+            f"https://api.github.com/repos/{self.repository}/labels",
+            headers=self.headers,
+            json={"name": "Daily", "color": "1d76db", "description": "Automated AI daily"},
+            timeout=20,
+        )
+        created.raise_for_status()
+
+    async def find_publication(self, target_date: date) -> Publication | None:
+        expected_marker = marker(target_date)
+        issue = await self._find(target_date, expected_marker)
+        if not issue:
+            return None
+        return Publication(
+            target_date=target_date,
+            issue_number=int(str(issue["number"])),
+            issue_url=HttpUrl(str(issue["html_url"])),
+            status="issue_published",
+            marker=expected_marker,
+        )
+
+    async def _find(self, target_date: date, expected_marker: str) -> dict[str, Any] | None:
+        response = await self.client.get(
+            f"https://api.github.com/repos/{self.repository}/issues",
+            headers=self.headers,
+            params={"state": "all", "per_page": 100},
+            timeout=20,
+        )
+        response.raise_for_status()
+        title_matches = [
+            issue
+            for issue in response.json()
+            if "pull_request" not in issue and issue.get("title") == target_date.isoformat()
+        ]
+        matches = [issue for issue in title_matches if expected_marker in (issue.get("body") or "")]
+        if title_matches and not matches:
+            raise RuntimeError("an unmarked issue already exists for the target date")
+        if len(matches) > 1:
+            raise RuntimeError("multiple daily issues exist for the same date")
+        return matches[0] if matches else None

--- a/src/ai_daily/site_trust.py
+++ b/src/ai_daily/site_trust.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Protocol
+
+DAILY_LABEL = "Daily"
+DAILY_MARKER_RE = re.compile(r"<!-- ai-daily:\d{4}-\d{2}-\d{2}:v\d+ -->")
+TRUSTED_BOT = "github-actions[bot]"
+
+
+class UserLike(Protocol):
+    login: str
+
+
+class LabelLike(Protocol):
+    name: str
+
+
+class IssueLike(Protocol):
+    user: UserLike
+    labels: Iterable[LabelLike]
+    body: str | None
+
+
+def is_trusted_issue(issue: IssueLike, owner: str) -> bool:
+    if issue.user.login == owner:
+        return True
+    labels = {label.name for label in issue.labels}
+    body = issue.body or ""
+    return (
+        issue.user.login == TRUSTED_BOT
+        and DAILY_LABEL in labels
+        and DAILY_MARKER_RE.search(body) is not None
+    )

--- a/src/ai_daily/sources.py
+++ b/src/ai_daily/sources.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import asyncio
+import calendar
+import hashlib
+import time
+from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+from typing import Any, cast
+
+import feedparser
+import httpx
+from pydantic import HttpUrl
+
+from ai_daily.models import RawItem, SourceConfig, SourceHealth
+
+
+class SourceCollectionError(RuntimeError):
+    pass
+
+
+class SourceNotModified(RuntimeError):
+    pass
+
+
+def _published(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            parsed = parsedate_to_datetime(value)
+            return parsed.astimezone(UTC)
+        except (TypeError, ValueError):
+            try:
+                return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+            except ValueError:
+                return None
+    if hasattr(value, "tm_year"):
+        return datetime.fromtimestamp(calendar.timegm(value), tz=UTC)
+    return None
+
+
+class Collector:
+    def __init__(self, client: httpx.AsyncClient | None = None, per_host: int = 5) -> None:
+        self.client = client or httpx.AsyncClient(
+            headers={"User-Agent": "ai-daily/0.2 (+https://wjy9902.github.io/ai-daily/)"},
+            follow_redirects=True,
+        )
+        self._semaphore = asyncio.Semaphore(per_host)
+        self._validators: dict[str, dict[str, str]] = {}
+
+    async def collect(
+        self, sources: list[SourceConfig]
+    ) -> tuple[list[RawItem], list[SourceHealth]]:
+        enabled = [source for source in sources if source.enabled]
+        results = await asyncio.gather(*(self._collect_one(source) for source in enabled))
+        items: list[RawItem] = []
+        health: list[SourceHealth] = []
+        for source_items, source_health in results:
+            items.extend(source_items)
+            health.append(source_health)
+        return items, health
+
+    async def _collect_one(self, source: SourceConfig) -> tuple[list[RawItem], SourceHealth]:
+        started = time.monotonic()
+        try:
+            async with self._semaphore:
+                handler = getattr(self, f"_fetch_{source.kind}")
+                items = await handler(source)
+            health = SourceHealth(
+                source=source.name,
+                tier=source.tier,
+                status="ok",
+                item_count=len(items),
+                latency_ms=int((time.monotonic() - started) * 1000),
+            )
+            return items, health
+        except SourceNotModified:
+            health = SourceHealth(
+                source=source.name,
+                tier=source.tier,
+                status="not_modified",
+                item_count=0,
+                latency_ms=int((time.monotonic() - started) * 1000),
+            )
+            return [], health
+        except Exception as error:
+            health = SourceHealth(
+                source=source.name,
+                tier=source.tier,
+                status="failed",
+                item_count=0,
+                latency_ms=int((time.monotonic() - started) * 1000),
+                error=type(error).__name__,
+            )
+            return [], health
+
+    async def _get(self, source: SourceConfig, **kwargs: Any) -> httpx.Response:
+        headers = dict(kwargs.pop("headers", {}))
+        headers.update(self._validators.get(source.name, {}))
+        for attempt in range(3):
+            response = await self.client.get(
+                str(source.url),
+                timeout=source.timeout_seconds,
+                headers=headers,
+                **kwargs,
+            )
+            if response.status_code == 304:
+                raise SourceNotModified(source.name)
+            if response.status_code != 429 and response.status_code < 500:
+                response.raise_for_status()
+                self._remember_validators(source.name, response)
+                return response
+            if attempt == 2:
+                response.raise_for_status()
+            delay = min(float(response.headers.get("Retry-After", attempt + 1)), 10)
+            await asyncio.sleep(delay)
+        raise AssertionError("unreachable")
+
+    def _remember_validators(self, name: str, response: httpx.Response) -> None:
+        validators = {}
+        if response.headers.get("ETag"):
+            validators["If-None-Match"] = response.headers["ETag"]
+        if response.headers.get("Last-Modified"):
+            validators["If-Modified-Since"] = response.headers["Last-Modified"]
+        if validators:
+            self._validators[name] = validators
+
+    async def _fetch_rss(self, source: SourceConfig) -> list[RawItem]:
+        response = await self._get(source)
+        feed = feedparser.parse(response.content)
+        if feed.bozo and not feed.entries:
+            raise SourceCollectionError("invalid feed")
+        now = datetime.now(UTC)
+        items = []
+        for entry in feed.entries[: source.limit]:
+            url = entry.get("link")
+            title = entry.get("title")
+            if not url or not title:
+                continue
+            identifier = str(entry.get("id") or url)
+            items.append(
+                RawItem(
+                    source=source.name,
+                    source_tier=source.tier,
+                    source_item_id=identifier,
+                    url=url,
+                    title=str(title).strip(),
+                    summary=str(entry.get("summary") or entry.get("description") or ""),
+                    published_at=_published(
+                        entry.get("published_parsed") or entry.get("published")
+                    ),
+                    discovered_at=now,
+                    author=entry.get("author"),
+                )
+            )
+        return items
+
+    async def _fetch_hackernews(self, source: SourceConfig) -> list[RawItem]:
+        base = str(source.url).rstrip("/")
+        ids_response = await self.client.get(
+            f"{base}/topstories.json", timeout=source.timeout_seconds
+        )
+        ids_response.raise_for_status()
+        ids = ids_response.json()[: source.limit]
+
+        async def fetch_item(item_id: int) -> dict[str, Any]:
+            response = await self.client.get(
+                f"{base}/item/{item_id}.json", timeout=source.timeout_seconds
+            )
+            response.raise_for_status()
+            return cast(dict[str, Any], response.json())
+
+        values = await asyncio.gather(*(fetch_item(item_id) for item_id in ids))
+        now = datetime.now(UTC)
+        return [
+            RawItem(
+                source=source.name,
+                source_tier=source.tier,
+                source_item_id=str(item["id"]),
+                url=HttpUrl(
+                    str(item.get("url") or f"https://news.ycombinator.com/item?id={item['id']}")
+                ),
+                title=item["title"],
+                summary="",
+                published_at=datetime.fromtimestamp(item["time"], tz=UTC),
+                discovered_at=now,
+                author=item.get("by"),
+                metrics={"score": item.get("score", 0), "comments": item.get("descendants", 0)},
+            )
+            for item in values
+            if item and item.get("type") == "story" and item.get("title")
+        ]
+
+    async def _fetch_github_releases(self, source: SourceConfig) -> list[RawItem]:
+        response = await self._get(source, params={"per_page": source.limit})
+        now = datetime.now(UTC)
+        return [
+            RawItem(
+                source=source.name,
+                source_tier=source.tier,
+                source_item_id=str(release["id"]),
+                url=release["html_url"],
+                title=release.get("name") or release["tag_name"],
+                summary=(release.get("body") or "")[:10000],
+                published_at=_published(release.get("published_at")),
+                discovered_at=now,
+                author=(release.get("author") or {}).get("login"),
+            )
+            for release in response.json()
+            if not release.get("draft")
+        ]
+
+    async def _fetch_arxiv(self, source: SourceConfig) -> list[RawItem]:
+        response = await self._get(
+            source,
+            params={
+                "search_query": "cat:cs.AI OR cat:cs.LG OR cat:cs.CL",
+                "sortBy": "submittedDate",
+                "sortOrder": "descending",
+                "max_results": source.limit,
+            },
+        )
+        feed = feedparser.parse(response.content)
+        now = datetime.now(UTC)
+        return [
+            RawItem(
+                source=source.name,
+                source_tier=source.tier,
+                source_item_id=str(entry.id),
+                url=HttpUrl(str(entry.link)),
+                title=" ".join(str(entry.title).split()),
+                summary=" ".join(str(entry.get("summary", "")).split()),
+                published_at=_published(entry.get("published")),
+                discovered_at=now,
+                author=", ".join(author.name for author in entry.get("authors", [])),
+            )
+            for entry in feed.entries[: source.limit]
+        ]
+
+    async def _fetch_huggingface(self, source: SourceConfig) -> list[RawItem]:
+        response = await self._get(source, params={"limit": source.limit})
+        now = datetime.now(UTC)
+        items = []
+        for value in response.json()[: source.limit]:
+            paper = value.get("paper") or value
+            paper_id = paper.get("id") or paper.get("paperId")
+            title = paper.get("title")
+            if not paper_id or not title:
+                continue
+            items.append(
+                RawItem(
+                    source=source.name,
+                    source_tier=source.tier,
+                    source_item_id=str(paper_id),
+                    url=HttpUrl(f"https://huggingface.co/papers/{paper_id}"),
+                    title=title,
+                    summary=paper.get("summary") or paper.get("abstract") or "",
+                    published_at=_published(paper.get("publishedAt")),
+                    discovered_at=now,
+                    metrics={"upvotes": value.get("numUpvotes", 0)},
+                )
+            )
+        return items
+
+    async def _fetch_html(self, source: SourceConfig) -> list[RawItem]:
+        response = await self._get(source)
+        text = " ".join(response.text.split())[:10000]
+        digest = hashlib.sha256(response.content).hexdigest()
+        return [
+            RawItem(
+                source=source.name,
+                source_tier=source.tier,
+                source_item_id=digest,
+                url=source.url,
+                title=source.name,
+                summary=text,
+                discovered_at=datetime.now(UTC),
+            )
+        ]

--- a/src/ai_daily/verifier.py
+++ b/src/ai_daily/verifier.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import date
+
+import feedparser
+import httpx
+from pydantic import HttpUrl
+
+from ai_daily.models import Publication
+
+
+class PublicationNotVisible(RuntimeError):
+    pass
+
+
+async def verify_publication(
+    target_date: date,
+    site_base_url: str,
+    issue_number: int,
+    client: httpx.AsyncClient | None = None,
+) -> Publication:
+    http = client or httpx.AsyncClient(follow_redirects=True)
+    page_url = f"{site_base_url.rstrip('/')}/issue-{issue_number}/"
+    rss_url = f"{site_base_url.rstrip('/')}/rss.xml"
+    page, rss = await http.get(page_url, timeout=20), await http.get(rss_url, timeout=20)
+    if page.status_code != 200:
+        raise PublicationNotVisible(f"page returned {page.status_code}")
+    rss.raise_for_status()
+    feed = feedparser.parse(rss.content)
+    if not feed.entries:
+        raise PublicationNotVisible("RSS has no entries")
+    latest = feed.entries[0]
+    if latest.get("link", "").rstrip("/") != page_url.rstrip("/"):
+        raise PublicationNotVisible("RSS latest entry does not point to today's page")
+    if target_date.isoformat() not in latest.get("title", ""):
+        raise PublicationNotVisible("RSS latest title does not contain the target date")
+    return Publication(
+        target_date=target_date,
+        issue_number=issue_number,
+        page_url=HttpUrl(page_url),
+        rss_url=HttpUrl(rss_url),
+        status="verified",
+        marker=f"verified:{target_date.isoformat()}",
+    )

--- a/tests/evals/judge-golden.json
+++ b/tests/evals/judge-golden.json
@@ -1,0 +1,22 @@
+[
+  {"id":"case-01","title":"OpenAI 发布 Linux 桌面应用","summary":"OpenAI 官方发布 Linux 桌面应用预览并列出支持的发行版。","url":"https://openai.com/news/linux-app","expected_selected":true,"expected_category":"模型与平台"},
+  {"id":"case-02","title":"Qwen 开放新模型权重","summary":"Qwen 团队正式开放新一代 27B 模型权重与许可证。","url":"https://qwenlm.github.io/blog/release","expected_selected":true,"expected_category":"模型与平台"},
+  {"id":"case-03","title":"Pydantic AI 发布新版本","summary":"官方 release 增加新的模型 provider 与结构化输出修复。","url":"https://github.com/pydantic/pydantic-ai/releases/tag/v1","expected_selected":true,"expected_category":"值得试的项目"},
+  {"id":"case-04","title":"Google 发布多模态医疗研究","summary":"Google Research 论文展示实时视频问诊的受控实验结果。","url":"https://research.google/blog/amie-video","expected_selected":true,"expected_category":"前沿研究"},
+  {"id":"case-05","title":"Hugging Face 推出推理服务更新","summary":"官方公告新增批处理与成本控制接口。","url":"https://huggingface.co/blog/inference-update","expected_selected":true,"expected_category":"模型与平台"},
+  {"id":"case-06","title":"DeepSeek 更新 API 模型","summary":"官方 API 文档上线新模型并调整 JSON 输出能力。","url":"https://api-docs.deepseek.com/updates/model","expected_selected":true,"expected_category":"模型与平台"},
+  {"id":"case-07","title":"Meta 开源多模态模型","summary":"Meta 官方仓库发布 Apache-2.0 多模态模型、权重和评测。","url":"https://github.com/meta-ai/model","expected_selected":true,"expected_category":"值得试的项目"},
+  {"id":"case-08","title":"arXiv 论文改进长上下文推理","summary":"论文提供完整方法、消融实验和可复现代码。","url":"https://arxiv.org/abs/2608.00001","expected_selected":true,"expected_category":"前沿研究"},
+  {"id":"case-09","title":"国内模型平台调整 API 定价","summary":"厂商官方公告给出新价格、生效时间和迁移说明。","url":"https://example.cn/official/pricing","expected_selected":true,"expected_category":"国内 AI"},
+  {"id":"case-10","title":"GitHub 开源 Agent 调试工具","summary":"项目发布稳定版，含许可证、文档和端到端示例。","url":"https://github.com/example/agent-debugger/releases/tag/v1","expected_selected":true,"expected_category":"值得试的项目"},
+  {"id":"case-11","title":"某公司普通人事任命","summary":"与模型、开发工具和产品能力无直接关系。","url":"https://example.com/hr-update","expected_selected":false,"expected_category":"快讯"},
+  {"id":"case-12","title":"未经证实的新模型传闻","summary":"匿名账号声称模型即将发布，没有官方来源或可验证材料。","url":"https://example.com/rumor","expected_selected":false,"expected_category":"快讯"},
+  {"id":"case-13","title":"AI 公司办公室搬迁","summary":"公司搬到新的办公地址，没有产品或技术变化。","url":"https://example.com/office","expected_selected":false,"expected_category":"快讯"},
+  {"id":"case-14","title":"旧论文再次登上社交媒体","summary":"论文两年前已发布，本次没有修订、代码或新结果。","url":"https://arxiv.org/abs/2401.00001","expected_selected":false,"expected_category":"快讯"},
+  {"id":"case-15","title":"泛泛的 AI 趋势评论","summary":"文章没有数据、产品变化、论文或一手证据。","url":"https://example.com/opinion","expected_selected":false,"expected_category":"快讯"},
+  {"id":"case-16","title":"与 AI 无关的区块链营销活动","summary":"活动只包含代币促销和抽奖信息。","url":"https://example.com/token","expected_selected":false,"expected_category":"快讯"},
+  {"id":"case-17","title":"模型服务区域性故障公告","summary":"官方状态页确认 API 大面积故障并提供恢复时间线。","url":"https://status.example.com/incidents/1","expected_selected":true,"expected_category":"行业动态"},
+  {"id":"case-18","title":"中国团队发布端侧推理框架","summary":"官方仓库提供移动端基准、许可证和安装说明。","url":"https://github.com/example-cn/edge-inference","expected_selected":true,"expected_category":"国内 AI"},
+  {"id":"case-19","title":"模型安全漏洞与修复","summary":"官方安全公告披露影响范围、版本和修复方案。","url":"https://example.com/security/advisory","expected_selected":true,"expected_category":"行业动态"},
+  {"id":"case-20","title":"小幅文档排版更新","summary":"项目只修改 README 标点，没有功能、接口或修复变化。","url":"https://github.com/example/project/commit/docs","expected_selected":false,"expected_category":"快讯"}
+]

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -1,0 +1,44 @@
+from datetime import UTC, date, datetime
+
+import pytest
+
+from ai_daily.assembler import assemble_markdown
+from ai_daily.models import DraftItem, Event, RawItem, SourceTier
+
+
+def _event(index: int) -> Event:
+    item = RawItem(
+        source="official",
+        source_tier=SourceTier.A,
+        source_item_id=str(index),
+        url=f"https://example.com/{index}",
+        title=f"Release {index}",
+        discovered_at=datetime(2026, 8, 12, tzinfo=UTC),
+    )
+    return Event(
+        event_id=f"event-{index}",
+        canonical_url=item.url,
+        title=item.title,
+        summary="Official release",
+        items=[item],
+    )
+
+
+def _draft(index: int) -> DraftItem:
+    return DraftItem(
+        event_id=f"event-{index}",
+        category="模型与平台",
+        title=f"模型发布 {index}",
+        tldr="官方发布新模型。",
+        facts=["甲" * 500 for _ in range(5)],
+        why_it_matters="开发者需要评估。",
+        action="阅读公告并测试。",
+        evidence_ids=[f"event-{index}-1"],
+    )
+
+
+def test_issue_body_size_is_bounded() -> None:
+    events = [_event(index) for index in range(12)]
+    drafts = [_draft(index) for index in range(12)]
+    with pytest.raises(ValueError, match="Issue body limit"):
+        assemble_markdown(date(2026, 8, 12), drafts, events)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,56 @@
+import json
+
+import pytest
+
+from ai_daily.benchmark import PredictionRecord, load_dataset, score_records
+from ai_daily.models import JudgeDecision
+
+
+def case(index: int) -> dict[str, object]:
+    return {
+        "id": str(index),
+        "expected_selected": True,
+        "expected_category": "模型与平台",
+        "title": "Official model release",
+        "summary": "The provider released a model.",
+        "url": f"https://example.com/{index}",
+    }
+
+
+def test_benchmark_requires_20_cases(tmp_path) -> None:
+    dataset = tmp_path / "eval.json"
+    dataset.write_text(json.dumps([case(index) for index in range(20)]))
+    assert len(load_dataset(dataset)) == 20
+
+
+def test_benchmark_rejects_too_small_dataset(tmp_path) -> None:
+    dataset = tmp_path / "eval.json"
+    dataset.write_text(json.dumps([case(1)]))
+    with pytest.raises(ValueError, match="20"):
+        load_dataset(dataset)
+
+
+def test_benchmark_scores_evidence_selection_chinese_latency_and_cost() -> None:
+    records = [
+        PredictionRecord(
+            case_id=str(index),
+            expected_selected=True,
+            expected_category="模型与平台",
+            prediction=JudgeDecision(
+                event_id=str(index),
+                selected=True,
+                category="模型与平台",
+                relevance=90,
+                confidence=0.9,
+                reason="官方发布值得关注",
+                evidence_ids=[f"{index}-1"],
+            ),
+            latency_ms=100,
+            cost_cny=0.01,
+            fallback_used=False,
+        )
+        for index in range(20)
+    ]
+    result = score_records(records)
+    assert result["score"] == 100
+    assert result["eligible"] is True

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,54 @@
+import pytest
+
+from ai_daily.budget import BudgetExceeded, BudgetLedger
+from ai_daily.models import BudgetConfig, ModelRun
+
+
+def config() -> BudgetConfig:
+    return BudgetConfig(
+        request_limit=1,
+        input_token_limit=100,
+        output_token_limit=50,
+        cost_cny_limit=1,
+    )
+
+
+def run(**updates: object) -> ModelRun:
+    values = {
+        "role": "judge",
+        "requested_provider": "alibaba",
+        "requested_model": "model",
+        "actual_provider": "alibaba",
+        "actual_model": "model",
+        "attempt": 1,
+        "status": "ok",
+        "latency_ms": 1,
+        "input_tokens": 90,
+        "output_tokens": 40,
+        "cost_cny": 0.5,
+    }
+    values.update(updates)
+    return ModelRun.model_validate(values)
+
+
+def test_budget_records_usage_and_fails_before_second_request() -> None:
+    ledger = BudgetLedger(config())
+    ledger.reserve_request()
+    ledger.record(run())
+    assert ledger.input_tokens == 90
+    with pytest.raises(BudgetExceeded, match="request"):
+        ledger.reserve_request()
+
+
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        ({"input_tokens": 101}, "input"),
+        ({"output_tokens": 51}, "output"),
+        ({"cost_cny": 1.1}, "cost"),
+    ],
+)
+def test_budget_rejects_overages(updates: dict[str, object], message: str) -> None:
+    ledger = BudgetLedger(config())
+    with pytest.raises(BudgetExceeded, match=message):
+        ledger.record(run(**updates))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from ai_daily.config import load_config
+from ai_daily.models import ModelsConfig
+
+
+def test_project_config_loads_without_secrets() -> None:
+    config = load_config(Path("config"))
+    assert config.pipeline.selected_max == 12
+    assert config.models.roles["judge"].primary.provider == "alibaba"
+    text = "\n".join(path.read_text() for path in Path("config").glob("*.yaml"))
+    assert "sk-" not in text
+    assert "api_key:" not in text.lower()
+
+
+def test_model_fallback_must_cross_provider() -> None:
+    value = yaml.safe_load(Path("config/models.yaml").read_text())
+    value["roles"]["judge"]["fallback"]["provider"] = "alibaba"
+    with pytest.raises(ValidationError, match="different provider"):
+        ModelsConfig.model_validate(value)
+
+
+def test_ollama_cannot_be_production_fallback() -> None:
+    value = yaml.safe_load(Path("config/models.yaml").read_text())
+    value["roles"]["judge"]["fallback"]["provider"] = "ollama"
+    with pytest.raises(ValidationError, match="Ollama"):
+        ModelsConfig.model_validate(value)

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,0 +1,102 @@
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+from ai_daily.content import JudgeBatch, draft_selected, judge_events
+from ai_daily.models import DraftItem, Event, JudgeDecision, RawItem, SourceTier
+
+
+def event() -> Event:
+    item = RawItem(
+        source="official",
+        source_tier=SourceTier.A,
+        source_item_id="1",
+        url="https://example.com/release",
+        title="Official release",
+        summary="A new model was released.",
+        discovered_at=datetime(2026, 8, 12, tzinfo=UTC),
+    )
+    return Event(
+        event_id="event-1",
+        canonical_url=item.url,
+        title=item.title,
+        summary=item.summary,
+        items=[item],
+    )
+
+
+class FakeGateway:
+    async def generate(
+        self, role: str, output_type: type[BaseModel], instructions: str, prompt: str
+    ) -> Any:
+        if output_type is JudgeBatch:
+            return JudgeBatch(
+                root=[
+                    JudgeDecision(
+                        event_id="event-1",
+                        selected=True,
+                        category="模型与平台",
+                        relevance=95,
+                        confidence=0.9,
+                        reason="Official material change",
+                        evidence_ids=["event-1-1"],
+                    )
+                ]
+            )
+        return DraftItem(
+            event_id="event-1",
+            category="模型与平台",
+            title="模型正式发布",
+            tldr="官方发布了新模型。",
+            facts=["官方公告确认发布。"],
+            why_it_matters="开发者可以开始评估。",
+            action="阅读官方说明并运行小规模评测。",
+            evidence_ids=["event-1-1"],
+        )
+
+
+async def test_judge_and_editor_preserve_evidence_ids() -> None:
+    gateway = FakeGateway()
+    decisions = await judge_events(gateway, [event()])  # type: ignore[arg-type]
+    drafts = await draft_selected(gateway, [event()], decisions, 1, 1)  # type: ignore[arg-type]
+    assert drafts[0].evidence_ids == ["event-1-1"]
+
+
+class BadGateway(FakeGateway):
+    async def generate(
+        self, role: str, output_type: type[BaseModel], instructions: str, prompt: str
+    ) -> Any:
+        value = await super().generate(role, output_type, instructions, prompt)
+        if isinstance(value, DraftItem):
+            return value.model_copy(update={"evidence_ids": ["invented"]})
+        return value
+
+
+async def test_editor_cannot_invent_evidence() -> None:
+    decisions = await judge_events(BadGateway(), [event()])  # type: ignore[arg-type]
+    try:
+        await draft_selected(BadGateway(), [event()], decisions, 1, 1)  # type: ignore[arg-type]
+    except ValueError as error:
+        assert "unknown evidence" in str(error)
+    else:
+        raise AssertionError("invented evidence was accepted")
+
+
+class DuplicateJudgeGateway(FakeGateway):
+    async def generate(
+        self, role: str, output_type: type[BaseModel], instructions: str, prompt: str
+    ) -> Any:
+        value = await super().generate(role, output_type, instructions, prompt)
+        if isinstance(value, JudgeBatch):
+            return JudgeBatch(root=[value.root[0], value.root[0]])
+        return value
+
+
+async def test_judge_must_return_each_event_exactly_once() -> None:
+    try:
+        await judge_events(DuplicateJudgeGateway(), [event()])  # type: ignore[arg-type]
+    except ValueError as error:
+        assert "exactly once" in str(error)
+    else:
+        raise AssertionError("duplicate judge decision was accepted")

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,0 +1,43 @@
+import httpx
+from pydantic_ai.exceptions import ModelHTTPError
+
+from ai_daily.config import Secrets, load_config
+from ai_daily.model_gateway import MissingProviderSecret, ModelGateway, is_recoverable
+
+
+def test_only_transient_failures_are_recoverable() -> None:
+    assert is_recoverable(httpx.ConnectError("offline"))
+    assert is_recoverable(ModelHTTPError(429, "model"))
+    assert is_recoverable(ModelHTTPError(503, "model"))
+    assert not is_recoverable(ModelHTTPError(401, "model"))
+    assert not is_recoverable(ModelHTTPError(400, "model"))
+
+
+def test_provider_requires_environment_secrets() -> None:
+    gateway = ModelGateway(load_config().models, Secrets())
+    endpoint = gateway.config.roles["judge"].primary
+    try:
+        gateway._build_model(endpoint)
+    except MissingProviderSecret as error:
+        assert "DASHSCOPE_API_KEY" in str(error)
+    else:
+        raise AssertionError("missing secrets were accepted")
+
+
+def test_fallback_audit_preserves_requested_model() -> None:
+    gateway = ModelGateway(load_config().models, Secrets(), clock=lambda: 1.0)
+    role = gateway.config.roles["judge"]
+    run = gateway._success_run(
+        "judge",
+        role.primary,
+        role.fallback,
+        2,
+        "ModelHTTPError:503",
+        1.0,
+        100,
+        20,
+    )
+    assert run.requested_provider == role.primary.provider
+    assert run.requested_model == role.primary.model
+    assert run.actual_provider == role.fallback.provider
+    assert run.actual_model == role.fallback.model

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,39 @@
+from datetime import UTC, datetime
+
+from ai_daily.models import RawItem, SourceTier
+from ai_daily.normalize import canonicalize_url, cluster_items, remove_historical
+
+
+def item(item_id: str, url: str, title: str) -> RawItem:
+    return RawItem(
+        source="test",
+        source_tier=SourceTier.A,
+        source_item_id=item_id,
+        url=url,
+        title=title,
+        discovered_at=datetime(2026, 8, 12, tzinfo=UTC),
+    )
+
+
+def test_canonicalize_removes_tracking_and_fragment() -> None:
+    assert (
+        canonicalize_url("HTTPS://www.Example.com//post/?utm_source=x&a=1#part")
+        == "https://example.com/post?a=1"
+    )
+
+
+def test_cluster_exact_url_and_similar_title() -> None:
+    events = cluster_items(
+        [
+            item("1", "https://example.com/a?utm_source=x", "Qwen model release today"),
+            item("2", "https://example.com/a", "Qwen model release today"),
+            item("3", "https://other.com/b", "Qwen model release today announced"),
+        ]
+    )
+    assert len(events) == 1
+    assert len(events[0].items) == 3
+
+
+def test_history_filter_uses_canonical_url() -> None:
+    event = cluster_items([item("1", "https://example.com/a?utm_source=x", "Release")])[0]
+    assert remove_historical([event], {"https://www.example.com/a"}) == []

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from ai_daily.pipeline import collection_window
+
+
+def test_collection_window_uses_beijing_run_time() -> None:
+    timezone = ZoneInfo("Asia/Shanghai")
+    now = datetime(2026, 8, 12, 4, 20, tzinfo=timezone)
+    cutoff, run_time = collection_window(now.date(), "Asia/Shanghai", 36, now)
+    assert cutoff == datetime(2026, 8, 10, 16, 20, tzinfo=timezone)
+    assert run_time == now

--- a/tests/test_publisher.py
+++ b/tests/test_publisher.py
@@ -1,0 +1,87 @@
+from datetime import date
+
+import httpx
+
+from ai_daily.assembler import marker
+from ai_daily.publisher import GitHubPublisher
+
+
+async def test_publish_creates_then_updates_same_issue() -> None:
+    created = False
+    writes: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal created
+        if request.url.path.endswith("/labels/Daily"):
+            return httpx.Response(200, json={"name": "Daily"})
+        if request.method == "GET":
+            issues = []
+            if created:
+                issues = [
+                    {
+                        "number": 12,
+                        "title": "2026-08-12",
+                        "body": marker(date(2026, 8, 12)),
+                        "url": "https://api.github.com/repos/o/r/issues/12",
+                        "html_url": "https://github.com/o/r/issues/12",
+                    }
+                ]
+            return httpx.Response(200, json=issues)
+        writes.append(request.method)
+        created = True
+        return httpx.Response(
+            200 if request.method == "PATCH" else 201,
+            json={
+                "number": 12,
+                "html_url": "https://github.com/o/r/issues/12",
+            },
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    publisher = GitHubPublisher("o/r", "token", client)
+    body = f"{marker(date(2026, 8, 12))}\ncontent"
+    first = await publisher.publish(date(2026, 8, 12), body)
+    second = await publisher.publish(date(2026, 8, 12), body)
+    assert first.issue_number == second.issue_number == 12
+    assert writes == ["POST", "PATCH"]
+
+
+async def test_publish_rejects_unmarked_body() -> None:
+    publisher = GitHubPublisher("o/r", "token")
+    try:
+        await publisher.publish(date(2026, 8, 12), "content")
+    except ValueError as error:
+        assert "machine marker" in str(error)
+    else:
+        raise AssertionError("unmarked body was accepted")
+
+
+async def test_publish_rejects_existing_unmarked_issue() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/labels/Daily"):
+            return httpx.Response(200, json={"name": "Daily"})
+        if request.method == "GET":
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "number": 10,
+                        "title": "2026-08-12",
+                        "body": "legacy body",
+                        "url": "https://api.github.com/repos/o/r/issues/10",
+                        "html_url": "https://github.com/o/r/issues/10",
+                    }
+                ],
+            )
+        raise AssertionError("publisher attempted to overwrite the legacy issue")
+
+    publisher = GitHubPublisher(
+        "o/r", "token", httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    )
+    body = f"{marker(date(2026, 8, 12))}\ncontent"
+    try:
+        await publisher.publish(date(2026, 8, 12), body)
+    except RuntimeError as error:
+        assert "unmarked" in str(error)
+    else:
+        raise AssertionError("a duplicate issue would have been created")

--- a/tests/test_site_trust.py
+++ b/tests/test_site_trust.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+from ai_daily.site_trust import is_trusted_issue
+
+
+def issue(login: str, labels: list[str], body: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        user=SimpleNamespace(login=login),
+        labels=[SimpleNamespace(name=label) for label in labels],
+        body=body,
+    )
+
+
+def test_owner_is_always_trusted() -> None:
+    assert is_trusted_issue(issue("owner", [], "anything"), "owner")
+
+
+def test_bot_requires_daily_label_and_valid_marker() -> None:
+    valid = "<!-- ai-daily:2026-08-12:v1 -->"
+    assert is_trusted_issue(issue("github-actions[bot]", ["Daily"], valid), "owner")
+    assert not is_trusted_issue(issue("github-actions[bot]", [], valid), "owner")
+    assert not is_trusted_issue(issue("github-actions[bot]", ["Daily"], "none"), "owner")
+
+
+def test_untrusted_user_cannot_forge_daily_issue() -> None:
+    assert not is_trusted_issue(
+        issue("attacker", ["Daily"], "<!-- ai-daily:2026-08-12:v1 -->"), "owner"
+    )

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,70 @@
+import httpx
+
+from ai_daily.models import SourceConfig, SourceTier
+from ai_daily.sources import Collector
+
+
+async def test_rss_adapter_parses_valid_entries() -> None:
+    body = b"""<?xml version='1.0'?><rss version='2.0'><channel><title>T</title>
+    <item><guid>1</guid><title>New model</title><link>https://example.com/a</link>
+    <description>Details</description><pubDate>Wed, 12 Aug 2026 00:00:00 GMT</pubDate></item>
+    </channel></rss>"""
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=body))
+    )
+    source = SourceConfig(name="feed", kind="rss", url="https://example.com/rss", tier=SourceTier.A)
+    items, health = await Collector(client).collect([source])
+    assert [item.title for item in items] == ["New model"]
+    assert health[0].status == "ok"
+
+
+async def test_source_failure_is_visible_not_silent() -> None:
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(503, headers={"Retry-After": "0"})
+        )
+    )
+    source = SourceConfig(name="feed", kind="rss", url="https://example.com/rss", tier=SourceTier.A)
+    items, health = await Collector(client).collect([source])
+    assert items == []
+    assert health[0].status == "failed"
+    assert health[0].error == "HTTPStatusError"
+
+
+async def test_conditional_request_reports_not_modified() -> None:
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(
+                200,
+                headers={"ETag": '"v1"'},
+                content=b"<rss version='2.0'><channel><title>T</title></channel></rss>",
+            )
+        assert request.headers["If-None-Match"] == '"v1"'
+        return httpx.Response(304)
+
+    collector = Collector(httpx.AsyncClient(transport=httpx.MockTransport(handler)))
+    source = SourceConfig(name="feed", kind="rss", url="https://example.com/rss", tier=SourceTier.A)
+    await collector.collect([source])
+    _, health = await collector.collect([source])
+    assert health[0].status == "not_modified"
+
+
+async def test_hackernews_adapter_uses_public_api() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("topstories.json"):
+            return httpx.Response(200, json=[1])
+        return httpx.Response(
+            200,
+            json={"id": 1, "type": "story", "title": "AI tool", "time": 1786492800, "score": 100},
+        )
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    source = SourceConfig(
+        name="hn", kind="hackernews", url="https://hacker-news.firebaseio.com/v0", tier=SourceTier.B
+    )
+    items, _ = await Collector(client).collect([source])
+    assert str(items[0].url).startswith("https://news.ycombinator.com/item?id=1")

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -1,0 +1,42 @@
+from datetime import date
+
+import httpx
+import pytest
+
+from ai_daily.verifier import PublicationNotVisible, verify_publication
+
+
+def rss(link: str, title: str = "2026-08-12") -> bytes:
+    return f"""<?xml version='1.0'?><rss version='2.0'><channel><title>T</title>
+    <item><title>{title}</title><link>{link}</link><guid>{link}</guid></item>
+    </channel></rss>""".encode()
+
+
+async def test_verify_requires_page_and_matching_latest_rss() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("rss.xml"):
+            return httpx.Response(200, content=rss("https://site.test/issue-12/"))
+        return httpx.Response(200, text="digest")
+
+    result = await verify_publication(
+        date(2026, 8, 12),
+        "https://site.test",
+        12,
+        httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+    )
+    assert result.status == "verified"
+
+
+async def test_verify_rejects_stale_rss() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("rss.xml"):
+            return httpx.Response(200, content=rss("https://site.test/issue-11/"))
+        return httpx.Response(200)
+
+    with pytest.raises(PublicationNotVisible, match="latest"):
+        await verify_publication(
+            date(2026, 8, 12),
+            "https://site.test",
+            12,
+            httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        )

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+def test_daily_workflow_contains_all_beijing_schedule_conversions() -> None:
+    workflow = Path(".github/workflows/daily.yml").read_text()
+    assert 'cron: "20 20 * * *"' in workflow
+    assert 'cron: "5 21 * * *"' in workflow
+    assert 'cron: "45 21 * * *"' in workflow
+    assert "DASHSCOPE_API_KEY: ${{ secrets.DASHSCOPE_API_KEY }}" in workflow
+    assert "DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}" in workflow
+
+
+def test_site_workflow_is_reusable_and_locked() -> None:
+    workflow = Path(".github/workflows/generate_site.yml").read_text()
+    assert "workflow_call:" in workflow
+    assert "uv sync --frozen --no-dev" in workflow
+    assert "requirements.txt" not in workflow
+
+
+def test_recovery_does_not_call_model_when_issue_exists() -> None:
+    workflow = Path(".github/workflows/daily.yml").read_text()
+    recovery_start = workflow.index('elif [ "$SCHEDULE" = "5 21 * * *" ]')
+    recovery_end = workflow.index('elif [ "${MANUAL_MODE:-publish}"', recovery_start)
+    recovery = workflow[recovery_start:recovery_end]
+    assert "ai-daily issue-exists" in recovery
+    assert recovery.index("ai-daily issue-exists") < recovery.index("ai-daily run")

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -15,6 +15,8 @@ def test_site_workflow_is_reusable_and_locked() -> None:
     assert "workflow_call:" in workflow
     assert "uv sync --frozen --no-dev" in workflow
     assert "requirements.txt" not in workflow
+    assert "python main.py ${{ github.repository }}" in workflow
+    assert "python main.py ${{ github.token }}" not in workflow
 
 
 def test_recovery_does_not_call_model_when_issue_exists() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,1309 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
+
+[[package]]
+name = "ai-daily"
+version = "0.2.0"
+source = { editable = "." }
+dependencies = [
+    { name = "feedgen" },
+    { name = "feedparser" },
+    { name = "httpx" },
+    { name = "lxml" },
+    { name = "markdown" },
+    { name = "marko" },
+    { name = "pydantic-ai-slim", extra = ["openai"] },
+    { name = "pydantic-settings" },
+    { name = "pygithub" },
+    { name = "pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "respx" },
+    { name = "ruff" },
+    { name = "types-pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "feedgen", specifier = ">=1,<2" },
+    { name = "feedparser", specifier = ">=6,<7" },
+    { name = "httpx", specifier = ">=0.28,<1" },
+    { name = "lxml", specifier = ">=5,<7" },
+    { name = "markdown", specifier = ">=3.7,<4" },
+    { name = "marko", specifier = ">=2.1,<3" },
+    { name = "pydantic-ai-slim", extras = ["openai"], specifier = ">=1.0,<2" },
+    { name = "pydantic-settings", specifier = ">=2.7,<3" },
+    { name = "pygithub", specifier = ">=2.6,<3" },
+    { name = "pyyaml", specifier = ">=6,<7" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.15,<2" },
+    { name = "pyright", specifier = ">=1.1.400,<2" },
+    { name = "pytest", specifier = ">=8.3,<9" },
+    { name = "pytest-asyncio", specifier = ">=0.25,<1" },
+    { name = "respx", specifier = ">=0.22,<1" },
+    { name = "ruff", specifier = ">=0.11,<1" },
+    { name = "types-pyyaml", specifier = ">=6.0,<7" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964, upload-time = "2026-08-03T21:20:19.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504, upload-time = "2026-08-03T21:20:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933, upload-time = "2026-08-03T21:20:50.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464, upload-time = "2026-08-03T21:21:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "50.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03", size = 4001252, upload-time = "2026-07-31T14:23:33.331Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30", size = 3840395, upload-time = "2026-07-31T14:23:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/fb/951032a3bf22a5697c83183fb6294a4843772947a70e616c57b3ff5f522e/cryptography-50.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:49e7d93abdbd2990caced757e5fade25302f719c3c8fb6e6fff2dde98999fc41", size = 3989258, upload-time = "2026-07-31T14:23:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/67/91eb047e69c5e845f2f14b8a2e4a1aab0f283cb885531e9e22c8adb176bc/cryptography-50.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:19736989797678c6af1e55cd49055cdbcb55d8f6b5583ac5335f933aba9101dc", size = 4700648, upload-time = "2026-07-31T14:24:00.702Z" },
+    { url = "https://files.pythonhosted.org/packages/30/82/85f0f7425c856b9f96459411eb12e74ef72df9caf6f8f15bf23a33ff131f/cryptography-50.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80b63928fa35083b33966ce1efb70e5b9607181e49dcd1c22c8c005e319f667f", size = 4682442, upload-time = "2026-07-31T14:24:02.538Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/28/b555a365adff1cca2fbe7b9e487d68a40de6bc67ff2cb587473eb43de0e7/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d58c3db7cd6eed54e6c06744db55456b65ebd7492ddeae9c1e93cfca7aa857d3", size = 4707596, upload-time = "2026-07-31T14:24:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/72/d8/f52538140cc719df62a01cf87d1c7142318d235817109d6f4054d7c352d6/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:df2a58a472f332225671c35b0a830208b86d004f82baa8530fa3782c85646533", size = 5314552, upload-time = "2026-07-31T14:24:06.31Z" },
+    { url = "https://files.pythonhosted.org/packages/38/14/6120e5bd7c5aa022ad15424ba4d5c5269d0d9448ed4d55e492ea91e3c1c4/cryptography-50.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11b74db56cdbe3cdee6e3f6982ecb70334fa10dce99ed58bf7894aaaa3b2a037", size = 4717113, upload-time = "2026-07-31T14:24:08.349Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/190bf38c3ee2e0f8efc9860ae100c9df4169742eef274b91e7aa1cb133b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f59e38625469987d7ef6d495323c55e7db6c212eaf6112267e0d3b565a2e9c9f", size = 4338580, upload-time = "2026-07-31T14:24:10.227Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/504ccfbbe61fd8aa983f7f146399cdf034c72c2fc55f5b2dfdcdcdb20c99/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ecfed7367f965a0328cfbdd70da860f15441f002f613185668c6e6ebf5a0ac11", size = 4707038, upload-time = "2026-07-31T14:24:12.169Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/2cf79bbfc4d12ca106437a6e170d6aaa01a373e93093118aaaef0e801bd4/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:9aa87839c383bdbab6ef865787a1fb877af8dd03464c4400322726feaaadfc6d", size = 5273110, upload-time = "2026-07-31T14:24:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/8aae2972c520145377ea3559a605a899bebe227bf070b33cdb445929a9b9/cryptography-50.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:6ba6a53445bd3cfa809ef3ef5f1589aa6ba08784a1d962bf47d0940e871dab1c", size = 4716439, upload-time = "2026-07-31T14:24:16.415Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/20/4fe50b619a48c2525cc46e2dbc1ac490708d704be5d467bdaac6dc955682/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3f5735ffe4996d28b809371756219f5354864902a3b9e7c0b9ee87041209fc9c", size = 4837383, upload-time = "2026-07-31T14:24:18.553Z" },
+    { url = "https://files.pythonhosted.org/packages/92/91/3a31366e183343d3703f8995c095f5734676bd6938118047e50fcf279eb4/cryptography-50.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1b4a266766514614f8aa60416e71f2fc6e575d36e7bdc90f644fadb2f4b75b95", size = 4985772, upload-time = "2026-07-31T14:24:20.385Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9a/02ffe35b2853d121689871eb5dce862092562b3a1ed5cc98f1aaed441506/cryptography-50.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:12b9c6996425c76ea6c457ace4f3073e715b8c545add07cd1a8f3a4f90691269", size = 3816291, upload-time = "2026-07-31T14:24:22.125Z" },
+    { url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07", size = 4036009, upload-time = "2026-07-31T14:24:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "feedgen"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lxml" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/59/be0a6f852b5dfbf19e6c8e962c8f41407697f9f52a7902250ed98683ae89/feedgen-1.0.0.tar.gz", hash = "sha256:d9bd51c3b5e956a2a52998c3708c4d2c729f2fcc311188e1e5d3b9726393546a", size = 258496, upload-time = "2023-12-25T18:04:08.421Z" }
+
+[[package]]
+name = "feedparser"
+version = "6.0.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "feedparser-sgmllib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/8a/a53da4a77352045d277978a2df322d5379369f9deb1707178899ff7e1121/feedparser-6.0.14.tar.gz", hash = "sha256:088679b0c4b543ee211a820dd544698c76a402122eae7473c04a43425f283d06", size = 286108, upload-time = "2026-07-30T14:07:40.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/61/f04912e63702e73fb2a378f9c0a1ad9eb17a334a11a6b3fe1daa593903c2/feedparser-6.0.14-py3-none-any.whl", hash = "sha256:e35e3f760151b0c3b22cac9684155cae186a233e16c49bcbc6c49e91e3131137", size = 80668, upload-time = "2026-07-30T14:07:39.175Z" },
+]
+
+[[package]]
+name = "feedparser-sgmllib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/df/38596299216e5c22d60ed7f97902bb2bc72cfb95f732400f4fa976fd2e62/feedparser_sgmllib-2.1.0.tar.gz", hash = "sha256:61facf2918c4389b5b00714f76c5e03431ffcd94cd1f51d657edd6cd7c396579", size = 26845, upload-time = "2026-08-02T21:27:53.891Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/a0/79a31f898092e145bd66e2b338fb0656979acb2bbbcae8220940fbfcd820/feedparser_sgmllib-2.1.0-py3-none-any.whl", hash = "sha256:2cab2d43b95a954f920f18aebce7a4dbbb3f539780b127e2aa114f579821e01d", size = 11652, upload-time = "2026-08-02T21:27:52.894Z" },
+]
+
+[[package]]
+name = "genai-prices"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx2" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/9b/85e646305a90a2da18f1edf055498668391e71f9849d3e1754d66559a311/genai_prices-0.1.1.tar.gz", hash = "sha256:54a2237691e0aaefb057d10a0c3c20160accc9fc09521c64c03fcdb7a4a69f68", size = 91182, upload-time = "2026-08-01T09:02:49.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/5e/cfe36dff790ffad6aeff8a069b6f36743987ac17053579035ee0a67635dd/genai_prices-0.1.1-py3-none-any.whl", hash = "sha256:de2e3d8ea3ca1d0d292025995c598da447a74e94f22cd3342df46941aeb5416b", size = 95300, upload-time = "2026-08-01T09:02:48.308Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+]
+
+[[package]]
+name = "librt"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/9b/356320fbae2ac8467e21c5e73e1389c80468e4998c62cc7d3536cc51b614/librt-0.15.0.tar.gz", hash = "sha256:4e66cbe84437497d951b799d3e1551291b6fb3d643820a7014b3655d57a59162", size = 214338, upload-time = "2026-08-07T10:49:42.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/42/467b53a601b406ccd7b97c1fd54b59cb34f9185ad5ce7e9d5c3c4e8961c8/librt-0.15.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:db13ca398005abcbe538deda87b686d9bd08b7001cf40c4c06b444960ae10a26", size = 151029, upload-time = "2026-08-07T10:47:19.312Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/e6/36c2299b7a94b84fdd01220d8a777a71be5be0925bb0dbdf71c0a06a34d9/librt-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:aa1f1995789dca3698bc550aaceb09a51bd5df0a057ff84ff15296cd1975b801", size = 155194, upload-time = "2026-08-07T10:47:20.398Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b6/ed5071f9325845e670bd36012757419767fbf56af77ed483077b9e4db541/librt-0.15.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55456ea87d8df21808446d03817be2f65e20391c1c615d9187440dff28cd08dc", size = 502568, upload-time = "2026-08-07T10:47:21.652Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/6450c67c3615d87704bcbc21323fafc69c799b06a044c447529f725d4b01/librt-0.15.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:5a86a5a08c2235316bdb359d5dbb6ce0abfca7fac06363103e2c5af571d92f95", size = 496153, upload-time = "2026-08-07T10:47:22.925Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/d6/5f52b722bc75076954b3bfd49be15ea362df4d580c6fb315d0f617100d30/librt-0.15.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e56b6a368529bed262da40ce13f8fef590db0479819cca84f16a1f01ac356d0b", size = 513336, upload-time = "2026-08-07T10:47:24.213Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e2/c08fd1d36ce63ea5a12b85c5d37f4550b5f86a692167e41e5a74222607ae/librt-0.15.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:234d8d394721fa0d786af15ebf1f3fb7f3ed82fd1cd0cde45c2f247b5d4281d2", size = 531661, upload-time = "2026-08-07T10:47:25.507Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d8/d9482fcbeb177b9eb87bb3899eeb3b42be690313c652f9e146b1d0681fb2/librt-0.15.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d8363d7accb0286ac3a0e633f396e93800dafb8150494505daf9515bbda591f3", size = 524487, upload-time = "2026-08-07T10:47:26.79Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cc/075171517b41f861753034fbb151b42cfc83bcc853849f24f5e66fd60ccf/librt-0.15.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0f0ee3644d951f31055ad07d77d92520e84505dd7a432cc4cd501dd70ee06785", size = 543201, upload-time = "2026-08-07T10:47:27.999Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/03/42c2330f37eeb475b6affeedd06518f60035f323af3a839335e3fc9fef2d/librt-0.15.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2cfd1a81a648806e6a7717be4cc4d1bb392fa229752bf8444ba365e381e984d6", size = 546467, upload-time = "2026-08-07T10:47:29.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/1e/1ad4c5638f7e64d8560328bd25c54b409a661bdb6ff254b38ff90744288d/librt-0.15.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:a6cd22c9da0d866558e46a041f1cc0c2bbb26b61b137b2347fa834c332e1d101", size = 555139, upload-time = "2026-08-07T10:47:30.815Z" },
+    { url = "https://files.pythonhosted.org/packages/49/41/39fa7d15db1204cd1cbe6514680fbdc243adf754a0885061308f43afc013/librt-0.15.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:6d5225ef8801e4ea5e482fa9b5dfb891dd9ef6f6d870f1f25d449ca2c70ac218", size = 536050, upload-time = "2026-08-07T10:47:32.222Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/88/c6dcf0dd8e26dc0c9a499a2abab8646c86dcaf9ecea9524cb46d3686331a/librt-0.15.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d28a05796b99f749bf8794f17ba9ba1612d0076b802e9cfc62c554634e9ce3b", size = 573700, upload-time = "2026-08-07T10:47:33.527Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9b/ab54c71a7918a7c34fa5327fb61390a77446a07a146fbfb1165250a61035/librt-0.15.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:2067ff438048cead9d223ca5675bae2a25e520a7c3e6c1498bf9c6892d22caab", size = 82194, upload-time = "2026-08-07T10:47:34.835Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b2/4f9a243bb892395f3becb80789ade13771701091f9f07ab8230247953ba8/librt-0.15.0-cp313-cp313-win32.whl", hash = "sha256:1cd3b721f24c206398b9e26da3c3a9c011e6e89d06f318ba8ebefc30f1003890", size = 106231, upload-time = "2026-08-07T10:47:36.251Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/af/64aff4885a40b93132382f2c314647d722574605416504379184ef3045ea/librt-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:f395a4a9a03ac062dbe9a9f82e0c720502e590a38feee6a757bc82e9c63afbd8", size = 126996, upload-time = "2026-08-07T10:47:37.453Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/335bccf6c7cb9028cb0b54aead27d9ece3f01f83bc6baa2abace5da655c1/librt-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:0a15cb554761247d84a3ec0cbdf4078d70725384f0e4662c0fa3b26266eb60ad", size = 112188, upload-time = "2026-08-07T10:47:38.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/93/949053fb462eecc4a9a5ee770a81f4b40be7b79538b245545d4aebc6b58b/librt-0.15.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f5de7feedc56337a088eb15cd9fafa9938367362221d8cc62c642b7f94821993", size = 149833, upload-time = "2026-08-07T10:47:39.86Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ca/8281aa6cd560a3420e4497729f6b704b53be3eeaaef82d5aeadddaf7441f/librt-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c0eb900c0e91f4aebe680845242e614f1864edfd44106380d0752ac29522bf8", size = 154088, upload-time = "2026-08-07T10:47:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/02/1a1662dceaba6a086360891448d5ce9a7d3555976cae59a31a39d744b9c7/librt-0.15.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e8c9a650a188e38bac005048cbe6342e81407782944d01934540ab75e417df21", size = 494215, upload-time = "2026-08-07T10:47:42.388Z" },
+    { url = "https://files.pythonhosted.org/packages/69/84/99211619dc656370a3740c33d2b0b6d5a3fb1e73689314f6ed477a397dc4/librt-0.15.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:92bfed8deec93df30286b9fe9e3b1dd17329cc076a192b4ee5ec223841d54953", size = 491173, upload-time = "2026-08-07T10:47:43.683Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/aa/5448d0b05f4579b635d3899176817ebf561af0e57bacd425b5b1887264c1/librt-0.15.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ec4b19788f835711a2072f9dbe6b03b3bf32ed1f0fb30cf399bdd59d9f0c33fa", size = 505512, upload-time = "2026-08-07T10:47:45.314Z" },
+    { url = "https://files.pythonhosted.org/packages/95/82/01940e40b83c43a546c4a3c896cf34ca272a9690899d55914e4827b3dcce/librt-0.15.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4c7bacb70930f3d0a56f4ecf1be474a1f0d941b01dd73b756f3c256d42cb879", size = 523073, upload-time = "2026-08-07T10:47:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fa/759c0030f3ee371439eb26de34fc745807caf0abb878af7af4b8b7c3dd3d/librt-0.15.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3e79f05e4a08b4d880342673312bbc895b56df7765605796f15902eb5367d3ae", size = 515080, upload-time = "2026-08-07T10:47:48.319Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/27/894e072228fcb159703c655da69f8cd10dbed489c36e3df7dd032a2483be/librt-0.15.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a417149c0cba4d50b61e992e5a15e69eaf96746609b461cc4ed168aeef6b79dd", size = 534164, upload-time = "2026-08-07T10:47:49.875Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a3/0078e91c1f36f8815db17827de15650b9a3fe56c55fbf998c854b34e40d3/librt-0.15.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:da7a94d6a3411f579d72aa3e3bc5fbca7ed4549f3dbd7e5de3aa567333374285", size = 540616, upload-time = "2026-08-07T10:47:51.408Z" },
+    { url = "https://files.pythonhosted.org/packages/86/33/81a29b796dd52a45e9ef7974c7732926e8f10f15b8d2be505665979f896d/librt-0.15.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:856f743ae607f2c1380eccb566c0038a9fb3eabf0fc2be2704d76d9f73557239", size = 545890, upload-time = "2026-08-07T10:47:52.818Z" },
+    { url = "https://files.pythonhosted.org/packages/05/82/8be1baa1350e5d30cfd70ae79d0a6f4dc5862ef47f7bb2808aabc9bb86e5/librt-0.15.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:779a6e7c894737e5983e7790a9c78c4000c30e23c9aada08081bdbea53b0fa60", size = 523287, upload-time = "2026-08-07T10:47:54.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4f/d1be6a01a35c20ef734e0e44113f87d4af756a9354a89dcfbe3b4f8af5e1/librt-0.15.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:96bb17dbe8bab3c0954fbebfc69ed395599de75b6bbc35e3270a878e15d4dd65", size = 565868, upload-time = "2026-08-07T10:47:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/67/88/649cfa33f5825927b160610f670bdab012a64d627eddb94fa795ea4292fd/librt-0.15.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:7220697efaa6e5348fc3d18ee7f8563d4bfecd9872b37ffb915bfc1d08840622", size = 81619, upload-time = "2026-08-07T10:47:56.886Z" },
+    { url = "https://files.pythonhosted.org/packages/22/31/8e88a8d5e48fc8d1a817787fb6811dfff6499acd6c8683dd83934aa6ede0/librt-0.15.0-cp314-cp314-win32.whl", hash = "sha256:f54598964d357b1c5ab77cf5d92f21e598fe0e23cdbe9618480807f81b4eba15", size = 100138, upload-time = "2026-08-07T10:47:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/80/92/20fd6c4b6a1b1a564b076d55cd3d427d8428217d7638dc25a654cc4791d4/librt-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:3ff5893a2c23d886aa9ce786de5ac6ddc74aeeaf90743682b74d920e117d2e28", size = 121258, upload-time = "2026-08-07T10:47:59.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/28/6af430b44d9ebb897b865a3c363b6dcace51357be2347cc0f8f869656a86/librt-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:3722a099730704c9a3d70c879fc0f51daec25fe5f1555672d97bc595abeafb95", size = 106467, upload-time = "2026-08-07T10:48:01.097Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/aa/b42bb798942ced219f6d63b27e07f91237887a8d0bd0921666db79a13790/librt-0.15.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:38c0c7d4b6fc06c3324b3f9162c8391bfc4fd9dde53afe1033ce7edb48d5a714", size = 159523, upload-time = "2026-08-07T10:48:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/75/03/1b53cd4ef904e73b1d828a5f90143bf94a2967d7cfff0b9ccf93e12aa9b4/librt-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8b2fdd7ead3c995c37940a790690660d0ca006c302db26cc51933f6766866fc3", size = 161638, upload-time = "2026-08-07T10:48:03.725Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/c4/9f9c9fba097d49e9e694c2b4dc331df31884645ecbc58a93b4b5fc69d2c5/librt-0.15.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2fde98cf1fc4bac144ce23c2c4c017b924ba714509ea9334977b0b27050c837d", size = 701795, upload-time = "2026-08-07T10:48:05.135Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/05/0966840bda0380c8ae167b9043c6230202941cc90ea29c48e096964c765e/librt-0.15.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:e3b461183c5fa7681b48560f91515f53a953122fb30c71e07abc67d7ddf58c38", size = 682147, upload-time = "2026-08-07T10:48:06.555Z" },
+    { url = "https://files.pythonhosted.org/packages/18/af/1c47ca573c30ea47d195aec26133af522fea1104afaace028d7b32247ea8/librt-0.15.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4bbcc257e3babea20a91715c361b24554ec4e8f51aa578568afc230799fe1a19", size = 696397, upload-time = "2026-08-07T10:48:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0f/1aed6223d4f9f9d1171a8596ff100ea4c3f7699fea7a4ba657c3e60daa6c/librt-0.15.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b845b8d48088fad0cadc84be4b8fda63203be7e9237b71015b3925443c1f35ab", size = 722542, upload-time = "2026-08-07T10:48:09.569Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/22/9e3a929aea456c97d69e6ef3884efea56d4807f97399471cc946baebd8af/librt-0.15.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b30e600e8f337b9bd7f39b86d9fdfedc73cc46e3d0f745931a23a234220bb7e2", size = 729709, upload-time = "2026-08-07T10:48:11.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/1b/c327ef6018e3a9ca0b8e7c5eddeeb331ba8f9b76c24e126d37d0f6d62faf/librt-0.15.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:64b0c8c35aa4c4ed79896359f3e0b285cbe4e610042106500da4811c322cc108", size = 752891, upload-time = "2026-08-07T10:48:12.558Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d1/d5f1ea02c56930087009e39db9b70660a663e76c730b27b925d786718457/librt-0.15.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:0da0d94cb802f32a0524653e7201f2cef72d5f700a5407678f5290483d4fcd08", size = 745301, upload-time = "2026-08-07T10:48:14.55Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3c/5f7c585d15ebb2250c73e7c0ee4e9e47be72c65d520c07ddbcdc62037674/librt-0.15.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:4a6369168d371207339b1e50d4532b06a7121586141f82599505a3f315751d47", size = 747921, upload-time = "2026-08-07T10:48:16.453Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/52/1443a446486eba966bcbca1696b472e4f210320ec42f490a47f48fbf0fdc/librt-0.15.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c434e072557ade9cbc642d052c89d031efe47d5c9614523619d0d74a02378e81", size = 727561, upload-time = "2026-08-07T10:48:18.089Z" },
+    { url = "https://files.pythonhosted.org/packages/79/91/2270a9380f11725cf83ce1925a5e32dd1dde2be9bba597f25c10a38644e7/librt-0.15.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c7eec6a42018bc1d45763b1c162d3d2bf7c3b9a1b0ed30d3e91dcba390efefcc", size = 774417, upload-time = "2026-08-07T10:48:19.611Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/3b/f4b1548d4f5b99186737fe27aec238e9823e8d5d23bf4df007c030689dc5/librt-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:6912fa5e635d74529ac7cdb1bdf6ca3af4453da8d1edbe0110ee1cb4ad407ebf", size = 104381, upload-time = "2026-08-07T10:48:21.048Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/134afad262def1de04c0843c376d02135f1168af43f22e09a52bd8394727/librt-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8e11699ed745931c395acd3621b07062e0f840efa6935aad87a64ed0995f0915", size = 127034, upload-time = "2026-08-07T10:48:22.561Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5f/1b6846b20572bd699c9e9ec321a5f781845bee477df2aa2a43b28bc40119/librt-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5d2a91724463bfed4f573cd7a9fdc856d2e230d0c0e5a61416a93481dccd8605", size = 110827, upload-time = "2026-08-07T10:48:23.804Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/44/4de9f4ddadb009a55c7758eb5736d62534a7daaf27bd71bc50e64b606b06/librt-0.15.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:8443e38dcfcfdbcf5add5118c623efd788d65ac2e25756d6251a54a06a4d0aca", size = 149843, upload-time = "2026-08-07T10:48:25.148Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/eb/5d9ab71e30119c44094e0275f38b47dd327aea0f843a080396677029d508/librt-0.15.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:6d15a29033c57490cfe2069097c6fc4049e4e65ffbb749be7dc453b7c4c68965", size = 154510, upload-time = "2026-08-07T10:48:26.485Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/8505d1b8f5e8c19587bd03f7429993b3e9ce5c06819d856bfb11d919374c/librt-0.15.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d2c05c729b589e734c09578bf5964be48a911765484840d017bbc84f49d4c4ad", size = 497543, upload-time = "2026-08-07T10:48:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/9a/3a8390775cb095765aded027ac9c63e7c8ea74e731498607544c6505de0e/librt-0.15.0-cp315-cp315-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:fa60887537e1d0cd2d9982269d33a709bf54b195cd2b9364fc0a758022af5bd9", size = 480452, upload-time = "2026-08-07T10:48:29.531Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/40/258a4a7117ee915d66de5cd9b8ade65a440993161107ce3a686f1859955c/librt-0.15.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d8bc24219b24c0af375718942ab75e3544b2763085f40f965be4326734ae8328", size = 507768, upload-time = "2026-08-07T10:48:31.007Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/c6/2f4dd296c97a0b85b98894519b279408ec9dd602d4f692b1ea0e25dee670/librt-0.15.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86a21a7bd3fe3a419512ef424cc1c020f6771d0b29cfddff36d1635a855e63f0", size = 525122, upload-time = "2026-08-07T10:48:32.7Z" },
+    { url = "https://files.pythonhosted.org/packages/49/dd/29eab42be13b2bf0ea8cb227135a45d44693e30a7e8b92871981ff56b82b/librt-0.15.0-cp315-cp315-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dbab647e88d90b3167b91efe7091e248653688ed4337e4f90907a722c7361bb9", size = 520371, upload-time = "2026-08-07T10:48:34.294Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ed/4bad71adeca8fe208b775c2a35417fa5a2584c8f4791daaf89a89450fea1/librt-0.15.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:d8edcf6f550e918dca779c069b9e156385c60b406f99fc7641f32c52f7193659", size = 537258, upload-time = "2026-08-07T10:48:35.88Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/63/59dba6143fdcc7240c54458b629f3250000a61b8945890fc9efd451b19c5/librt-0.15.0-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:8b62076030baa2d8b1501a46bf0e19c27a489aa90671c55665bff7887f7660b0", size = 527432, upload-time = "2026-08-07T10:48:37.466Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/21/21a24c6a2327d8362580efebe77286bf47b0f4062ec5ea41766e609d3c7d/librt-0.15.0-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:d00d20d1818e82a07a0ee0aa89a98b17ed7916b92441090b683719cb20a59b6d", size = 548108, upload-time = "2026-08-07T10:48:39.384Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/6d/fc68c89a7971418b41f9a873623ff935cb864097544c6a2f8ce491c8ef5d/librt-0.15.0-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:4e6ee93fc3cf848dcbf0cce2eca73d8e7dcd0cc2b6df3a529d57750b30a4c55c", size = 529681, upload-time = "2026-08-07T10:48:41.392Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7e/c2d98766124400d722063a630b0fde38a9fc768705d37eecca15c47dc192/librt-0.15.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:32896a0af72508ea979e0acb4e4c04cbeeae04938167950d535c83c45597167d", size = 567736, upload-time = "2026-08-07T10:48:43.124Z" },
+    { url = "https://files.pythonhosted.org/packages/55/6c/f8c34a95e3a515c6e1c192b89511e7253c89a7760c6b500d57ffdb8d2dc8/librt-0.15.0-cp315-cp315-pyemscripten_2026_5_wasm32.whl", hash = "sha256:ec3ba415afaf951f6951b1dd16d3c8e4f540065fc382d7e70b823a79567ca374", size = 81673, upload-time = "2026-08-07T10:48:44.645Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9e/e23fa8e78679ec45728188650b39e8ff476c83b691c96f749217df3b1b7c/librt-0.15.0-cp315-cp315-win32.whl", hash = "sha256:d2813ba2503764f0450680c533d13df7cff9b49df1411062eded5f67db4195b9", size = 100081, upload-time = "2026-08-07T10:48:46.171Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/dc/3eb4c5e297343f0620a55532cd7c8d764d3001fa2159212dadf480464827/librt-0.15.0-cp315-cp315-win_amd64.whl", hash = "sha256:b87d67e33afaf265262f2a66db578284b88ee2e6fcd224579cb5c15518677ad8", size = 121228, upload-time = "2026-08-07T10:48:47.631Z" },
+    { url = "https://files.pythonhosted.org/packages/97/70/43abce19f04e49762f8ec834c8fafee13cc40fd6b94a72a24e534febfcd0/librt-0.15.0-cp315-cp315-win_arm64.whl", hash = "sha256:713bd7df21170b982e729e46870f31d6b437bd1a9b4648cffb529bd3c2ec5c4b", size = 106487, upload-time = "2026-08-07T10:48:49.095Z" },
+    { url = "https://files.pythonhosted.org/packages/de/15/83f2deddb9368b8951ec8c9477269b5b9b8bd9bbf15e57402d0f38817dca/librt-0.15.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:3de789c82752730f94782a5ee518baf9c05edf85733aeaf73bb6e518755cdf54", size = 159448, upload-time = "2026-08-07T10:48:50.649Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bf/043097353f9b3c73b583d07f6b8e552795463f4bfc8caf85e42eee50c26a/librt-0.15.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:e0b5deec9a8664eb722c797241970fd4aa1894d25fda36a1ddac0f7407606bd6", size = 161686, upload-time = "2026-08-07T10:48:52.174Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/2a/8ae77f9719d42ce71cd708560a3557b38ac3c17a0383e57f87084de45bbe/librt-0.15.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5563302a8359bc2295bb7084d1a8ed1519df96afb30eb2aa4e0bff7b54228988", size = 710668, upload-time = "2026-08-07T10:48:53.782Z" },
+    { url = "https://files.pythonhosted.org/packages/61/34/c0436ea134deb9a0d6da80a396a2739a81cb31e0418f7227239e23140898/librt-0.15.0-cp315-cp315t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:22d6263b9d39d7bbb286fa791945646e3218f1be2d693e36fb630f1d0e59cd13", size = 679396, upload-time = "2026-08-07T10:48:55.645Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9f/001e0d99aa9250d5cd5715a9081291a20656083459f9019cda15255329e1/librt-0.15.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:39ffd14646190c454f0d86e0d256b33f00a87a26ab410e619773b841d0e41416", size = 704313, upload-time = "2026-08-07T10:48:57.46Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/53/b34fa9d0ff00f136f4d58ebb4c411ff634baed1eb412bb602a2bc8dcafcb/librt-0.15.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c47318cd3a61401452de11282242937e3e057c4fd3dbaf601e269d0928a06c0a", size = 729847, upload-time = "2026-08-07T10:48:59.231Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ac/fa4d7a424665040e95baf480a6d523446057684b6758624c85338e8a23b2/librt-0.15.0-cp315-cp315t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a56a1d4f859a82ca5b99fc4b82c9b027b15e3c455c5cd99e7d0719f27bb20b6c", size = 742736, upload-time = "2026-08-07T10:49:01.151Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/e17a9bb5de6fb8c3186ed1a7d68d21618b027ac2d3633e03d3b6109c67ae/librt-0.15.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:077471b3182db4e17c36ae91555f36a4d2c00080b267f749bcad34a478a9a302", size = 763454, upload-time = "2026-08-07T10:49:03.039Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ec/ecd02cd30935b931b9cdbfed6ab5a099c51b280b4e7baa274da80978ed27/librt-0.15.0-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:411ca4d1b905b860ceba7570dd6717a71dedaddcc4b0f77ece710aa41ee11f8d", size = 743296, upload-time = "2026-08-07T10:49:04.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b5/b3c2b8353ce820a4854f78d19321344242f89fa71c975b71132ba9bf242a/librt-0.15.0-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:1256589e0b0adb31751d685a68bce29d73407ddf4ef05d4188f49d5dcf9566d9", size = 756217, upload-time = "2026-08-07T10:49:06.825Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/52/6cc22542ba59146b05cca2a656f9ff8bb67e38e63d12c3b0cc183d837bf1/librt-0.15.0-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:f42b74a53e5f26a0ba0007411a7455b66c67ce4022a39cc1f56fc4efd65bcbab", size = 741934, upload-time = "2026-08-07T10:49:08.839Z" },
+    { url = "https://files.pythonhosted.org/packages/40/32/a04b72b1aa86e3be23b2ecff8c1aad2dcc955bd3956d6d26e7e34267e57a/librt-0.15.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:291bf73caf78b9e88d6fae9bfd693207ff7d832e2fdbe2cf8e746bc13f5f892b", size = 783763, upload-time = "2026-08-07T10:49:10.661Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/f0/89eb11dffbe9279ff37144dec786927314502ae0b114f1449dc78c458aab/librt-0.15.0-cp315-cp315t-win32.whl", hash = "sha256:c16d15ee371643ab48dc8248a3e680ebbeca573a13af2c3dd0c985b142d77162", size = 104313, upload-time = "2026-08-07T10:49:12.305Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4a/1f1978c200f563beda63c36adff2d65bbecb81e365e8e69e572f5f70fbc6/librt-0.15.0-cp315-cp315t-win_amd64.whl", hash = "sha256:dbd605739f228912dc49027cb764456b9757750bdc2b6b7773164db7096c6fd1", size = 126889, upload-time = "2026-08-07T10:49:13.881Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a6/800800bfed7b1fb10fc3f3d557785c3854e80d3f7a9800d784b176a1fc2d/librt-0.15.0-cp315-cp315t-win_arm64.whl", hash = "sha256:84d244b00604d17df3fc7736c327892d6bba66181254aa4087be807b6c342bdc", size = 110700, upload-time = "2026-08-07T10:49:15.499Z" },
+]
+
+[[package]]
+name = "logfire-api"
+version = "4.40.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/5f/f4d0fb5c29d876c533daf415c0d961e1c4d0284167ed0834644a28581230/logfire_api-4.40.0.tar.gz", hash = "sha256:f4631d5ca6af95e9d4dadc4f63619ebb8f2300eecfca0ca99c84403d6ea605de", size = 90781, upload-time = "2026-08-05T11:27:00.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/be/ebe35d94e7d567b58d79bd7e1085fe85195ad4b8c8df8882a5a46caa4984/logfire_api-4.40.0-py3-none-any.whl", hash = "sha256:f8b7309235a942368b927f00e0a1869ff0820833f264a30e77a35f1da829c130", size = 140593, upload-time = "2026-08-05T11:26:58.395Z" },
+]
+
+[[package]]
+name = "lxml"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/3b/aab6728cae887456f409b4d75e8a01856e4f04bd510de38052a47768b680/lxml-6.1.1.tar.gz", hash = "sha256:ba96ae44888e0185281e937633a743ea90d5a196c6000f82565ebb0580012d40", size = 4197430, upload-time = "2026-05-18T19:19:06.424Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/eb/7e6f37c5584ccbb2ff267f56fd0339016938c1c8684cfefab9b33ffc2f36/lxml-6.1.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:68a9198d0fc122d14bb76837de9aa80cf84caed990b5b237f532ed87d3706736", size = 8559780, upload-time = "2026-05-18T19:17:57.661Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/36/587c2521cf23a2cd6c9c22108aa7528f683a1f195ed7ccd23a4b1786ad36/lxml-6.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7d47866cb32fb503450b6edc9df355d10dc49836af2e89901bd6ac6b0896d9d9", size = 4618006, upload-time = "2026-05-18T19:18:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ca/ab7bfe2bf4c972af5e7878262845ead3a24a929a9b04bc11c7c1ece6c82a/lxml-6.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb7c9811bfaa8b1ed5ed319f5d370dfbcaa59d52ea64be2a5a85e18195930354", size = 4924139, upload-time = "2026-05-18T19:19:04.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/55/a0c72851dfee5ecc689f949723a73dea457758912542cb955b108eaf0d8f/lxml-6.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:762ff394d5bd56da0cf034a23dcce4e13923f15321a2adfa2ac00201dc6d3fca", size = 5082329, upload-time = "2026-05-18T19:19:09.728Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b6/0608f7d61a3b96cc67e5648a3d906e31a5082093e10e7be65b3886289938/lxml-6.1.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a088f287f7d8275a33c07f2cac6c50b9319309a0200a39e7e75d80c707723099", size = 4993564, upload-time = "2026-05-18T19:19:13.608Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/66/ae227524b066d29d55bf0b453d93d2d793c40218657d643dcbbca13b8faf/lxml-6.1.1-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e902da4b04e6b52e5893900d4b8ab46068f75f3561f01bf1080957f9fd932ed6", size = 5613467, upload-time = "2026-05-18T19:19:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/76/dbe4a00b50385e40194231dcfe5a12c059de7cf90e89c83407d2b085b719/lxml-6.1.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d4962d4c66bf830a7e59ed6cfc17d148149898a3aefa8ec6e59763e6e3ed085", size = 5228304, upload-time = "2026-05-18T19:19:19.354Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/01/00b1b8442ed2041793336868ba0b9ea4b13d7da7c085c6404c207a63bf79/lxml-6.1.1-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:581d4c8ae690a6609e64862dd6b7c2489635c2d13907fc2b20f2bc200ff1d21e", size = 5341607, upload-time = "2026-05-18T19:19:22.297Z" },
+    { url = "https://files.pythonhosted.org/packages/63/36/1ad29931e9a4638bb707869f01d423a6c815f82152138d1a40dfcfde2b95/lxml-6.1.1-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:876e1ff5930ed8bf295ec5ef9a8155e9b6b1876bbf1deed8b3a8069311875a8f", size = 4700168, upload-time = "2026-05-18T19:19:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/a9536cecf9be18a0dc72d32bead283a2332d1ffebd2dd3ac70ce444686e5/lxml-6.1.1-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9eb9b5a968f6e0f6d640092a567e14529ff8cea2e29d00da6f78a79fa49f013c", size = 5232487, upload-time = "2026-05-18T19:19:28.603Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/77/b4fb1e03bf5d130e879214d3100092e386418807fb74dd0adc4b0a48f351/lxml-6.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:aa49e06d94aba782c6a02eecb7e507969e7e7a41b267f1b359bb35585f295d5b", size = 5044231, upload-time = "2026-05-18T19:18:42.246Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4c/d00daeeb0a5530c4028a9232aa1b93db3ef4ed2158c116ea73c79a9765b3/lxml-6.1.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:70cdfd80589d59e43e18005dd7244e8895e93db8ab6a620b7e23df5445a4e3d2", size = 4769450, upload-time = "2026-05-18T19:18:48.013Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/715a3a8d156ce42f29cf014706f5410c2ff3b02267774110fc23266409fe/lxml-6.1.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:aad9aa39483ed8ec44d6d2e59e5b98a0d80676ef0d92f44bfc374836111f62f5", size = 5635874, upload-time = "2026-05-18T19:18:51.914Z" },
+    { url = "https://files.pythonhosted.org/packages/45/37/0544bc21dde2a88f3a17b504e6fc79c0e01d25a33c2f6079724e9e72b9c7/lxml-6.1.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:d49514be2f28d895c38cf9d2b72d7b9a07d00314519f456c0b50b53cfcf4c785", size = 5223987, upload-time = "2026-05-18T19:18:59.715Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f8/f6a5e8185bcb28c2befae3d31f8e3df3b811cb0f47746517a81279fcafe1/lxml-6.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:47402e62c52ff5988c1e8c6c63177f5708bccf48e366dea4e3dcf1e645e04947", size = 5250276, upload-time = "2026-05-18T19:19:03.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f2/1a2b9f1b7a49d45495369be7ef9ad05b262930f2eab3e3145706fca8083f/lxml-6.1.1-cp313-cp313-win32.whl", hash = "sha256:3483644525531e1d5762b0c44a8e18b6efba321b6dcf8a8952de10b037618bca", size = 3596903, upload-time = "2026-05-18T19:17:29.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/99/f4ffb024f238eec2131aaa09f3278fb6129cf892741bf68e1fc1afb8c100/lxml-6.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:a10bd2fd62e8ce916ececb342f348f190724a098c1faa056fdfb2a22ad5e8660", size = 3995869, upload-time = "2026-05-18T19:18:02.596Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/53/70eb8c5c6037f27448f1e3c54ebede9545a801ae63f0a7254afca4fe8e45/lxml-6.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:424aa57aca0897eb922aef34395bd1289b3b6f04e6bae20ea123c0c7e333cffc", size = 3658490, upload-time = "2026-05-19T19:22:53.846Z" },
+    { url = "https://files.pythonhosted.org/packages/13/e2/2e325795566de01d0d7c3bb57d3c370616b2d07b01214e84eec5d3b10963/lxml-6.1.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:19b7ab10b210b0b3ad7985d9ac4eb66ab09a90b20fe6e2f7ba55d01a234345d0", size = 8577146, upload-time = "2026-05-18T19:18:17.765Z" },
+    { url = "https://files.pythonhosted.org/packages/93/cf/5630b5e4be7d2e6bee8efe83865c925221103cf0221303b104ce134b01e2/lxml-6.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c08e5c694306507275f2290073350c4f32e383db15213b2c69e7ff39c1193840", size = 4623866, upload-time = "2026-05-18T19:18:30.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/51/3904907c063451cf8d4a5c9fe0cad95fa1f4ec57f4e3884fa0731bd7a305/lxml-6.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:74a9717fd0d82effef5c2854f0d917231d5324b5a3eb7275c43ac9fa32f97a14", size = 4950022, upload-time = "2026-05-18T19:19:31.958Z" },
+    { url = "https://files.pythonhosted.org/packages/94/cd/9c7611a51c37a2830928405817cc5d56a97f64fab83cc3f628748b135749/lxml-6.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:efe0374196335f93b53269acd811b944f2e6bdc88e8894f214bd636455484909", size = 5086695, upload-time = "2026-05-18T19:19:34.764Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d6/24e3b5906abb0b674ff2ae195bc3ce59708df2bcd17cf17703b2d7dd643a/lxml-6.1.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac931cdc9442c1763b8a8f6cd62c0c938737eafc5be75eff88df55fc73bc0d00", size = 5031642, upload-time = "2026-05-18T19:19:37.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/db/6ec54f99019838bff54785c51da07f189eb4676861c5f2730962b0d8d665/lxml-6.1.1-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:aee395f5d0927f947758b4ec119fd5fc8ec71f07a1c5c52077b30b04c0fa6955", size = 5647338, upload-time = "2026-05-18T19:19:40.553Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/ef4dcfffd22d27a61805d8ed9f7fb888495bc6aa88648fa07c1eaa5586b6/lxml-6.1.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9395002973c827b3ed67db77e6ec09f092919a587022174554096a269378fb13", size = 5239528, upload-time = "2026-05-18T19:19:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/62/bb/37fb3f0dff146bdcfa78eec47879273820b2a0bf350ec236ce14bd0b1c26/lxml-6.1.1-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:73bc2086f141224ebddb7fc5c6a36ca58b31b94b561e1dfe8e073e3270fad1e7", size = 5350730, upload-time = "2026-05-18T19:19:46.307Z" },
+    { url = "https://files.pythonhosted.org/packages/90/42/43253f168388df4fae1f38c01df36ddb9bee39e2048167b54cdcbae85ea3/lxml-6.1.1-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:3779def59032b81e44a5f70096ef6bf2082f8d901937dca354474ba09782e245", size = 4697530, upload-time = "2026-05-18T19:19:49.889Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a8/c5a8504f81bbdfc8e7094c2c850cdb4ed6777fc4d5ddd9e5ab819f3b0d54/lxml-6.1.1-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:86c89b9d55ebf820ad7c90bc533410f0d098054f293351f10603c0c46ff598f5", size = 5250670, upload-time = "2026-05-18T19:19:53.199Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b7/c7e76ab18744d75e21f320ebf9ff9d1ceae2b54dd431ea5a64caf26c9672/lxml-6.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19607c6bbff2a44cf3fe8250abccd20942d3462473e0a721d01d379ed017e462", size = 5084485, upload-time = "2026-05-18T19:19:08.422Z" },
+    { url = "https://files.pythonhosted.org/packages/31/31/b35c53f8ef7b7c31cacd23d3638652fff7bcd1deb6eedb709ab43b685908/lxml-6.1.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:c6ed5141a5c7507cf3ee76bd363b0d6f801e3321adc35b5d825a23115faa5465", size = 4737635, upload-time = "2026-05-18T19:19:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/06/31f23c813a7fe8e0cb1b175e915b08c9bf4e86d225b210feadbdbe519667/lxml-6.1.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:62aeb7e85b5d60320b9d77eef2e773994e2c0ce10121b277e0a19804e1654a5a", size = 5670681, upload-time = "2026-05-18T19:19:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bc/ce619bccc89b1fd9ad8a8e1330ee3f3beff9f2ff95b712d7bbcdd6e22fc3/lxml-6.1.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b1b963fd8f5caa68e99dfae060d54de1fe9cba899b8718b44a00cdca53c3e590", size = 5238229, upload-time = "2026-05-18T19:19:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/5d/b329acbbedc0b619ebc2be6cf7ee9ed07e80892c88d4dfd612c33805789a/lxml-6.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:63876be28efefa04a1df615b46770e82042cce445cfdce55160522f57b231ccb", size = 5264191, upload-time = "2026-05-18T19:19:21.118Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/85/be36fb1425b30db3c3f9df75fe86343ebffb79e6320bd7f588e25bfeac39/lxml-6.1.1-cp314-cp314-win32.whl", hash = "sha256:7f7a92e8583f06b1fd49d01158143b8461cfcd135dcb10ec807270a3051bd603", size = 3657202, upload-time = "2026-05-18T19:17:39.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ce/3cf9a827342269f54d405a6202397de63f07c69cbd6ce7d183a3f0cba1e9/lxml-6.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:b2d444f2e66624d68e9c6b211e28a76e22fff5fcabcfff4deac18b529b7d4137", size = 4064497, upload-time = "2026-05-18T19:18:14.662Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/3e/1a957bde8f0760039e627f94699f82caa782c9d838d86c3d28245ee67212/lxml-6.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:3fd9728a2735fda14f4e8235830c86b539e9661e849665bf926d3f867943b4bf", size = 3741991, upload-time = "2026-05-19T19:22:59.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b2/00ed55b3a2efa4658fb795c38d1090ec9b3e8a6c3683d4441fa517f09c3b/lxml-6.1.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:787b2496d0dbe8cd180984e8d29e3a6f76e7ea34db781cb3bd55e4ba1ef8b4ee", size = 8827545, upload-time = "2026-05-18T19:18:41.193Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/73/74573db19baa618d5f266f2407898b087ff6927115b00b71e5fc1b700847/lxml-6.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2c8daa471358dc2d6fcf02165e80ec68f77871a286df95bc5cc3816153b0fd2c", size = 4735736, upload-time = "2026-05-18T19:18:46.761Z" },
+    { url = "https://files.pythonhosted.org/packages/16/02/6f7061f4f95f51e545d48e87647c54791d204a4e881be4156e7a26ba5338/lxml-6.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:acd7d70b64c0aae0c7922cca83d288a16f5f6da523637697872253415269baef", size = 4970291, upload-time = "2026-05-18T19:19:56.215Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/02/55fc057d8283427dea7d6edb102e7a840239c77a64a983d92f62a304c0e9/lxml-6.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4f0dd2f01f9f8a89f565d000e03abcf0a13d692a346c8d22f628d49af098777a", size = 5102822, upload-time = "2026-05-18T19:19:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/48/8e1cf78d89d66850121d9255a2a24414c98f775da93b90cf976956c24b14/lxml-6.1.1-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b7e8a14c8634bf6f7a568634cb395305a6d964aeb5b7ee32248094bed3a7e2c", size = 5027923, upload-time = "2026-05-18T19:20:01.549Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/00/0632a0647612c8af24d26997b3b961397daa9d5b2581444805933629a4cb/lxml-6.1.1-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:86281fbdd6a8162756f8d603f37e3435bfa38043adb79c6dc6a2dfee065e7525", size = 5595843, upload-time = "2026-05-18T19:20:03.93Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/86/ab008a7dc360711b66858d61c80a5979a70a09f2aa2b05d9698df80b803d/lxml-6.1.1-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5d7152ec39ca7c402d8fb9bad86140a15b9503bd0c54484e3f1bbe3dd37ceca", size = 5224515, upload-time = "2026-05-18T19:20:06.381Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c6/2702ff375e728e34f56d9a45339a9cf7e4427e917f542225242d63a05afa/lxml-6.1.1-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:88d8cb75b9d82858497a5393e3c63cfbf03035225e4b35a49ed7ccb151e4dc0e", size = 5312511, upload-time = "2026-05-18T19:20:09.308Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/a5807c98f87a86f10ef9ffab35516df7c0f0c4b6d5d33e9f608ab9c04a31/lxml-6.1.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f64ec5397ea6a41fc1b4af0380d79b44a755b5531dcaccd9940fb260dca93038", size = 4639206, upload-time = "2026-05-18T19:20:11.704Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/e1/8a0a2c35734812395f4da4eaf33748a7e5705bfb2a58b128da764339d5ec/lxml-6.1.1-cp314-cp314t-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d34bbf07dbc7ca5970671b1512e928991fb5e9d95365636c9b2d8b4f53af405e", size = 5232404, upload-time = "2026-05-18T19:20:14.064Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e2/0e6a4dd5ad84d01d99aa7bae7cfefd4a760a0e0f8176818241de17d9b6c0/lxml-6.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:17e0e18d4ad8adbd0399291bc44845b69d9dd68439a3cdebdf35ff902ec05072", size = 5083769, upload-time = "2026-05-18T19:19:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/7e/161f33d463f6ffc1c7679104b65086dea120080d49dde4d238f015aaee2f/lxml-6.1.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:3ab541146f1f6968c462d6c2ac495148e8cdba2f8347700b2141b6ec5a75bf52", size = 4758936, upload-time = "2026-05-18T19:19:27.256Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/fb/2369825e3f6ca99305bf9f7b7085fda91c8b0922a89e54d900974aa3ef85/lxml-6.1.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2a0217714657e023ef4293500f65aa20fce6164c8fd6b08fa5bd4a859fb14b9b", size = 5620296, upload-time = "2026-05-18T19:19:29.993Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/d61e383146f74c5ab683947ea14dc7b82778838ab9b95ea73a23b60d0191/lxml-6.1.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:05a82eb6e1530a64f26225b55cbd178113bd0b5af1c2b625f25e5296742c26d2", size = 5228598, upload-time = "2026-05-18T19:19:33.523Z" },
+    { url = "https://files.pythonhosted.org/packages/76/2d/2dafd8149e94b05bb070690efd5bb2680720681e03ff03fc57d2b70a1105/lxml-6.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9e36f163528fc50cbef305f02a5fd66d404edf7049cdaff211dbc2cba5a7013e", size = 5247845, upload-time = "2026-05-18T19:19:36.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/68/b30e913340c380ddac9580c6e6230991fc37240ec4f64704833e4f3e2769/lxml-6.1.1-cp314-cp314t-win32.whl", hash = "sha256:649dda677cf3bd6ac9ae14007ba0c824ded8ce5808b53fc7431d9140399118c1", size = 3897345, upload-time = "2026-05-18T19:17:33.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/4e/9eb2af5335545f9fbcd7af57bcf87c6025d31eaa31b14ec184a6c8675328/lxml-6.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:793033d6c5cdf33a573f910d9bea14ef8f5771820411d118da8e1182edb53d5e", size = 4393350, upload-time = "2026-05-18T19:18:10.076Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/2c/0f1e93c636720e8a3eb59af2bfda99d98b55891e1c53bc30c2e0e865f01b/lxml-6.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:58bb955caba94e467d2a96da17660d2d704e0675894cba21ab8a775b8621fd1c", size = 3817223, upload-time = "2026-05-19T19:22:56.823Z" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/6f/da4c6aea59b3001f2e8c0ec7497475aadaf3b021c10cab5b2858f0f32b26/markdown-3.10.3.tar.gz", hash = "sha256:3589362618f743188b4d955b874402bc814f4f83f544dc207719f4baa7d9c45f", size = 372596, upload-time = "2026-07-30T19:05:29.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/69/4a5af2bc115a9a33fefe51709749de8262be3f9ba063d1753a837cdbc49c/markdown-3.10.3-py3-none-any.whl", hash = "sha256:fa6c92a00a4a3c98b22728c64a935ae1928250ae65058a6ded814d2cc29a4cea", size = 110757, upload-time = "2026-07-30T19:05:27.883Z" },
+]
+
+[[package]]
+name = "marko"
+version = "2.2.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/6d/671a18bb386adca6311bca6c2fe6bec873947ee501cc5f8f509ec06bdde0/marko-2.2.4.tar.gz", hash = "sha256:c042c66f835425673123d7536b39b4660de3b68e30078c70fd26245b31170683", size = 151013, upload-time = "2026-08-12T03:20:11.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/78/751d49c8bdfa0b30147c99235516433af6b63eca367ff28593c7346a0494/marko-2.2.4-py3-none-any.whl", hash = "sha256:d80510506edba096ec49d4720a09645fa0bb78e7b7b88697f20032fc19730aa9", size = 46753, upload-time = "2026-08-12T03:20:10.811Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.20.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/af/e3d4b3e9ec91a0ff9aabfdb38692952acf49bbb899c2e4c29acb3a6da3ae/mypy-1.20.2.tar.gz", hash = "sha256:e8222c26daaafd9e8626dec58ae36029f82585890589576f769a650dd20fd665", size = 3817349, upload-time = "2026-04-21T17:12:28.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/c4/b93812d3a192c9bcf5df405bd2f30277cd0e48106a14d1023c7f6ed6e39b/mypy-1.20.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:edfbfca868cdd6bd8d974a60f8a3682f5565d3f5c99b327640cedd24c4264026", size = 14524670, upload-time = "2026-04-21T17:10:30.737Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/47/42c122501bff18eaf1e8f457f5c017933452d8acdc52918a9f59f6812955/mypy-1.20.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e2877a02380adfcdbc69071a0f74d6e9dbbf593c0dc9d174e1f223ffd5281943", size = 13336218, upload-time = "2026-04-21T17:08:44.069Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/75bbc92f41725fbd585fb17b440b1119b576105df1013622983e18640a93/mypy-1.20.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7488448de6007cd5177c6cea0517ac33b4c0f5ee9b5e9f2be51ce75511a85517", size = 13724906, upload-time = "2026-04-21T17:08:01.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/32/4c49da27a606167391ff0c39aa955707a00edc500572e562f7c36c08a71f/mypy-1.20.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb9c2fa06887e21d6a3a868762acb82aec34e2c6fd0174064f27c93ede68ad15", size = 14726046, upload-time = "2026-04-21T17:11:22.354Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/fc/4e354a1bd70216359deb0c9c54847ee6b32ef78dfb09f5131ff99b494078/mypy-1.20.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9d56a78b646f2e3daa865bc70cd5ec5a46c50045801ca8ff17a0c43abc97e3ee", size = 14955587, upload-time = "2026-04-21T17:12:16.033Z" },
+    { url = "https://files.pythonhosted.org/packages/62/b2/c0f2056e9eb8f08c62cafd9715e4584b89132bdc832fcf85d27d07b5f3e5/mypy-1.20.2-cp313-cp313-win_amd64.whl", hash = "sha256:2a4102b03bb7481d9a91a6da8d174740c9c8c4401024684b9ca3b7cc5e49852f", size = 10922681, upload-time = "2026-04-21T17:06:35.842Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/14/065e333721f05de8ef683d0aa804c23026bcc287446b61cac657b902ccac/mypy-1.20.2-cp313-cp313-win_arm64.whl", hash = "sha256:a95a9248b0c6fd933a442c03c3b113c3b61320086b88e2c444676d3fd1ca3330", size = 9830560, upload-time = "2026-04-21T17:07:51.023Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d1/b4ec96b0ecc620a4443570c6e95c867903428cfcde4206518eafdd5880c3/mypy-1.20.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:419413398fe250aae057fd2fe50166b61077083c9b82754c341cf4fd73038f30", size = 14524561, upload-time = "2026-04-21T17:06:27.325Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/63/d2c2ff4fa66bc49477d32dfa26e8a167ba803ea6a69c5efb416036909d30/mypy-1.20.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e73c07f23009962885c197ccb9b41356a30cc0e5a1d0c2ea8fd8fb1362d7f924", size = 13363883, upload-time = "2026-04-21T17:11:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/56/983916806bf4eddeaaa2c9230903c3669c6718552a921154e1c5182c701f/mypy-1.20.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c64e5973df366b747646fc98da921f9d6eba9716d57d1db94a83c026a08e0fb", size = 13742945, upload-time = "2026-04-21T17:08:34.181Z" },
+    { url = "https://files.pythonhosted.org/packages/19/65/0cd9285ab010ee8214c83d67c6b49417c40d86ce46f1aa109457b5a9b8d7/mypy-1.20.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a65aa591af023864fd08a97da9974e919452cfe19cb146c8a5dc692626445dc", size = 14706163, upload-time = "2026-04-21T17:05:15.51Z" },
+    { url = "https://files.pythonhosted.org/packages/94/97/48ff3b297cafcc94d185243a9190836fb1b01c1b0918fff64e941e973cc9/mypy-1.20.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fef51b01e638974a6e69885687e9bd40c8d1e09a6cd291cca0619625cf1f558", size = 14938677, upload-time = "2026-04-21T17:05:39.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a1/1b4233d255bdd0b38a1f284feeb1c143ca508c19184964e22f8d837ec851/mypy-1.20.2-cp314-cp314-win_amd64.whl", hash = "sha256:913485a03f1bcf5d279409a9d2b9ed565c151f61c09f29991e5faa14033da4c8", size = 11089322, upload-time = "2026-04-21T17:06:44.29Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/ce7ee2ba36aeb954ba50f18fa25d9c1188578654b97d02a66a15b6f09531/mypy-1.20.2-cp314-cp314-win_arm64.whl", hash = "sha256:c3bae4f855d965b5453784300c12ffc63a548304ac7f99e55d4dc7c898673aa3", size = 10017775, upload-time = "2026-04-21T17:07:20.732Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/a1/9d93a7d0b5859af0ead82b4888b46df6c8797e1bc5e1e262a08518c6d48e/mypy-1.20.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:2de3dcea53babc1c3237a19002bc3d228ce1833278f093b8d619e06e7cc79609", size = 15549002, upload-time = "2026-04-21T17:08:23.107Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d2/09a6a10ee1bf0008f6c144d9676f2ca6a12512151b4e0ad0ff6c4fac5337/mypy-1.20.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:52b176444e2e5054dfcbcb8c75b0b719865c96247b37407184bbfca5c353f2c2", size = 14401942, upload-time = "2026-04-21T17:07:31.837Z" },
+    { url = "https://files.pythonhosted.org/packages/57/da/9594b75c3c019e805250bed3583bdf4443ff9e6ef08f97e39ae308cb06f2/mypy-1.20.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:688c3312e5dadb573a2c69c82af3a298d43ecf9e6d264e0f95df960b5f6ac19c", size = 15041649, upload-time = "2026-04-21T17:09:34.653Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/f75a65c278e6e8eba2071f7f5a90481891053ecc39878cc444634d892abe/mypy-1.20.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29752dbbf8cc53f89f6ac096d363314333045c257c9c75cbd189ca2de0455744", size = 15864588, upload-time = "2026-04-21T17:11:44.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/46/1a4e1c66e96c1a3246ddf5403d122ac9b0a8d2b7e65730b9d6533ba7a6d3/mypy-1.20.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:803203d2b6ea644982c644895c2f78b28d0e208bba7b27d9b921e0ec5eb207c6", size = 16093956, upload-time = "2026-04-21T17:10:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2c/78a8851264dec38cd736ca5b8bc9380674df0dd0be7792f538916157716c/mypy-1.20.2-cp314-cp314t-win_amd64.whl", hash = "sha256:9bcb8aa397ff0093c824182fd76a935a9ba7ad097fcbef80ae89bf6c1731d8ec", size = 12568661, upload-time = "2026-04-21T17:11:54.473Z" },
+    { url = "https://files.pythonhosted.org/packages/83/01/cd7318aa03493322ce275a0e14f4f52b8896335e4e79d4fb8153a7ad2b77/mypy-1.20.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e061b58443f1736f8a37c48978d7ab581636d6ab03e3d4f99e3fa90463bb9382", size = 10389240, upload-time = "2026-04-21T17:09:42.719Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/f23c163e25b11074188251b0b5a0342625fc1cdb6af604757174fa9acc9b/mypy-1.20.2-py3-none-any.whl", hash = "sha256:a94c5a76ab46c5e6257c7972b6c8cff0574201ca7dc05647e33e795d78680563", size = 2637314, upload-time = "2026-04-21T17:05:54.5Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "openai"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx2" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/8c/2f500e8be09d1ae98c530467962535198b02cd4550cd418bbbaedc8b2910/openai-3.0.0.tar.gz", hash = "sha256:ffd00ef1678d70957e1f1ed98d5bfcf1d661f41ea4482f22e7d0144a66435a49", size = 1123740, upload-time = "2026-08-12T01:55:50.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/0d/9850e7eddb5e66da4439ed503e78e09ad1fd0195e6df51e4236c75763581/openai-3.0.0-py3-none-any.whl", hash = "sha256:8d32ac3a6647a66910d6cb8a64f0fa5a6c823604b6e82db83d9d055c6709bd51", size = 1665775, upload-time = "2026-08-12T01:55:48.678Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-ai-slim"
+version = "1.107.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "genai-prices" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "opentelemetry-api" },
+    { name = "pydantic" },
+    { name = "pydantic-graph" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/3a/6598d86998e5a6f2eedfd1d64397c8d29cb49dc5f515f873974db797e36e/pydantic_ai_slim-1.107.4.tar.gz", hash = "sha256:3ed2ca7a73b30067747331831d5b9f39938575dff5e4bf73ef11ea9b3af2b170", size = 783311, upload-time = "2026-08-12T03:58:05.588Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/97/b450636a6aee0a20bb7637f69838c11077c48ad49e4601f0c0b4ad3aef9b/pydantic_ai_slim-1.107.4-py3-none-any.whl", hash = "sha256:439cdd8f8a164deefa42960a7e7a74b5cb60eefdc4d3a0067ce3bf39078c3536", size = 967512, upload-time = "2026-08-12T03:57:58.462Z" },
+]
+
+[package.optional-dependencies]
+openai = [
+    { name = "openai" },
+    { name = "tiktoken" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+]
+
+[[package]]
+name = "pydantic-graph"
+version = "1.107.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "logfire-api" },
+    { name = "pydantic" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/ff/b9a33406005bf95bf20a279aa8c3cbcbb1634fce6c97878c670eb7fc4f6f/pydantic_graph-1.107.4.tar.gz", hash = "sha256:7a7309e7b53739cab5a12dd1bf8c33ebd9ecd62fd9fa0b7c1fac3e545e6988d3", size = 62569, upload-time = "2026-08-12T03:58:07.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/5c/1209e440ce02bcce6d7716b89a67680ffd4492ce9be1be6ee124ee35b674/pydantic_graph-1.107.4-py3-none-any.whl", hash = "sha256:6502abe529257de564fc21fb4fa35f69e1daf5e22a7d014b34be6c82e9c27d8e", size = 80106, upload-time = "2026-08-12T03:58:01.493Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+]
+
+[[package]]
+name = "pygithub"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "pynacl" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/c3/8465a311197e16cf5ab68789fe689535e90f6b61ab524cc32a39e67237ae/pygithub-2.9.1.tar.gz", hash = "sha256:59771d7ff63d54d427be2e7d0dad2208dfffc2b0a045fec959263787739b611c", size = 2594989, upload-time = "2026-04-14T07:26:13.622Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/aa/81a5506f089a26338bff17535e4339b3b22049ebd1bcdeff756c4d7a7559/pygithub-2.9.1-py3-none-any.whl", hash = "sha256:2ec78fca30092d51a42d76f4ddb02131b6f0c666a35dfdf364cf302cdda115b9", size = 449710, upload-time = "2026-04-14T07:26:12.382Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
+name = "pynacl"
+version = "1.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/79/0e3c34dc3c4671f67d251c07aa8eb100916f250ee470df230b0ab89551b4/pynacl-1.6.2-cp314-cp314t-macosx_10_10_universal2.whl", hash = "sha256:622d7b07cc5c02c666795792931b50c91f3ce3c2649762efb1ef0d5684c81594", size = 390064, upload-time = "2026-01-01T17:31:57.264Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/1c/23a26e931736e13b16483795c8a6b2f641bf6a3d5238c22b070a5112722c/pynacl-1.6.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d071c6a9a4c94d79eb665db4ce5cedc537faf74f2355e4d502591d850d3913c0", size = 809370, upload-time = "2026-01-01T17:31:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/8d4b718f8a22aea9e8dcc8b95deb76d4aae380e2f5b570cc70b5fd0a852d/pynacl-1.6.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe9847ca47d287af41e82be1dd5e23023d3c31a951da134121ab02e42ac218c9", size = 1408304, upload-time = "2026-01-01T17:32:01.162Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/73/be4fdd3a6a87fe8a4553380c2b47fbd1f7f58292eb820902f5c8ac7de7b0/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:04316d1fc625d860b6c162fff704eb8426b1a8bcd3abacea11142cbd99a6b574", size = 844871, upload-time = "2026-01-01T17:32:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ad/6efc57ab75ee4422e96b5f2697d51bbcf6cdcc091e66310df91fbdc144a8/pynacl-1.6.2-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44081faff368d6c5553ccf55322ef2819abb40e25afaec7e740f159f74813634", size = 1446356, upload-time = "2026-01-01T17:32:04.452Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/928ee9c4779caa0a915844311ab9fb5f99585621c5d6e4574538a17dca07/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:a9f9932d8d2811ce1a8ffa79dcbdf3970e7355b5c8eb0c1a881a57e7f7d96e88", size = 826814, upload-time = "2026-01-01T17:32:06.078Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a9/1bdba746a2be20f8809fee75c10e3159d75864ef69c6b0dd168fc60e485d/pynacl-1.6.2-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:bc4a36b28dd72fb4845e5d8f9760610588a96d5a51f01d84d8c6ff9849968c14", size = 1411742, upload-time = "2026-01-01T17:32:07.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/2f/5e7ea8d85f9f3ea5b6b87db1d8388daa3587eed181bdeb0306816fdbbe79/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bffb6d0f6becacb6526f8f42adfb5efb26337056ee0831fb9a7044d1a964444", size = 801714, upload-time = "2026-01-01T17:32:09.558Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ea/43fe2f7eab5f200e40fb10d305bf6f87ea31b3bbc83443eac37cd34a9e1e/pynacl-1.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fef529ef3ee487ad8113d287a593fa26f48ee3620d92ecc6f1d09ea38e0709b", size = 1372257, upload-time = "2026-01-01T17:32:11.026Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/54/c9ea116412788629b1347e415f72195c25eb2f3809b2d3e7b25f5c79f13a/pynacl-1.6.2-cp314-cp314t-win32.whl", hash = "sha256:a84bf1c20339d06dc0c85d9aea9637a24f718f375d861b2668b2f9f96fa51145", size = 231319, upload-time = "2026-01-01T17:32:12.46Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/04/64e9d76646abac2dccf904fccba352a86e7d172647557f35b9fe2a5ee4a1/pynacl-1.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:320ef68a41c87547c91a8b58903c9caa641ab01e8512ce291085b5fe2fcb7590", size = 244044, upload-time = "2026-01-01T17:32:13.781Z" },
+    { url = "https://files.pythonhosted.org/packages/33/33/7873dc161c6a06f43cda13dec67b6fe152cb2f982581151956fa5e5cdb47/pynacl-1.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d29bfe37e20e015a7d8b23cfc8bd6aa7909c92a1b8f41ee416bbb3e79ef182b2", size = 188740, upload-time = "2026-01-01T17:32:15.083Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7b/4845bbf88e94586ec47a432da4e9107e3fc3ce37eb412b1398630a37f7dd/pynacl-1.6.2-cp38-abi3-macosx_10_10_universal2.whl", hash = "sha256:c949ea47e4206af7c8f604b8278093b674f7c79ed0d4719cc836902bf4517465", size = 388458, upload-time = "2026-01-01T17:32:16.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b4/e927e0653ba63b02a4ca5b4d852a8d1d678afbf69b3dbf9c4d0785ac905c/pynacl-1.6.2-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8845c0631c0be43abdd865511c41eab235e0be69c81dc66a50911594198679b0", size = 800020, upload-time = "2026-01-01T17:32:18.34Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/81/d60984052df5c97b1d24365bc1e30024379b42c4edcd79d2436b1b9806f2/pynacl-1.6.2-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22de65bb9010a725b0dac248f353bb072969c94fa8d6b1f34b87d7953cf7bbe4", size = 1399174, upload-time = "2026-01-01T17:32:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f7/322f2f9915c4ef27d140101dd0ed26b479f7e6f5f183590fd32dfc48c4d3/pynacl-1.6.2-cp38-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46065496ab748469cdd999246d17e301b2c24ae2fdf739132e580a0e94c94a87", size = 835085, upload-time = "2026-01-01T17:32:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d0/f301f83ac8dbe53442c5a43f6a39016f94f754d7a9815a875b65e218a307/pynacl-1.6.2-cp38-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8a66d6fb6ae7661c58995f9c6435bda2b1e68b54b598a6a10247bfcdadac996c", size = 1437614, upload-time = "2026-01-01T17:32:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/58/fc6e649762b029315325ace1a8c6be66125e42f67416d3dbd47b69563d61/pynacl-1.6.2-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:26bfcd00dcf2cf160f122186af731ae30ab120c18e8375684ec2670dccd28130", size = 818251, upload-time = "2026-01-01T17:32:25.69Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a8/b917096b1accc9acd878819a49d3d84875731a41eb665f6ebc826b1af99e/pynacl-1.6.2-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:c8a231e36ec2cab018c4ad4358c386e36eede0319a0c41fed24f840b1dac59f6", size = 1402859, upload-time = "2026-01-01T17:32:27.215Z" },
+    { url = "https://files.pythonhosted.org/packages/85/42/fe60b5f4473e12c72f977548e4028156f4d340b884c635ec6b063fe7e9a5/pynacl-1.6.2-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:68be3a09455743ff9505491220b64440ced8973fe930f270c8e07ccfa25b1f9e", size = 791926, upload-time = "2026-01-01T17:32:29.314Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f9/e40e318c604259301cc091a2a63f237d9e7b424c4851cafaea4ea7c4834e/pynacl-1.6.2-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b097553b380236d51ed11356c953bf8ce36a29a3e596e934ecabe76c985a577", size = 1363101, upload-time = "2026-01-01T17:32:31.263Z" },
+    { url = "https://files.pythonhosted.org/packages/48/47/e761c254f410c023a469284a9bc210933e18588ca87706ae93002c05114c/pynacl-1.6.2-cp38-abi3-win32.whl", hash = "sha256:5811c72b473b2f38f7e2a3dc4f8642e3a3e9b5e7317266e4ced1fba85cae41aa", size = 227421, upload-time = "2026-01-01T17:32:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ad/334600e8cacc7d86587fe5f565480fde569dfb487389c8e1be56ac21d8ac/pynacl-1.6.2-cp38-abi3-win_amd64.whl", hash = "sha256:62985f233210dee6548c223301b6c25440852e13d59a8b81490203c3227c5ba0", size = 239754, upload-time = "2026-01-01T17:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7d/5945b5af29534641820d3bd7b00962abbbdfee84ec7e19f0d5b3175f9a31/pynacl-1.6.2-cp38-abi3-win_arm64.whl", hash = "sha256:834a43af110f743a754448463e8fd61259cd4ab5bbedcf70f9dabad1d28a394c", size = 184801, upload-time = "2026-01-01T17:32:36.309Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156, upload-time = "2025-03-25T06:22:28.883Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694, upload-time = "2025-03-25T06:22:27.807Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.7.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/98/04b13f1ddfb63158025291c02e03eb42fbb7acb51d091d541050eb4e35e8/regex-2026.7.19.tar.gz", hash = "sha256:7e77b324909c1617cbb4c668677e2c6ae13f44d7c1de0d4f15f2e3c10f3315b5", size = 416440, upload-time = "2026-07-19T00:19:48.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/3d/84165e4299ff76f3a40fe1f2abf939e976f693383a08d2beea6af62bd2c1/regex-2026.7.19-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f035d9dc1d25eff9d361456572231c7d27b5ccd473ca7dc0adfce732bd006d40", size = 496552, upload-time = "2026-07-19T00:17:36.808Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/a65293e6e4cf28eb7ee1be5335a5386c40d6742e9f47fafc8fec785e16c7/regex-2026.7.19-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c42572142ed0b9d5d261ba727157c426510da78e20828b66bbb855098b8a4e38", size = 296983, upload-time = "2026-07-19T00:17:38.816Z" },
+    { url = "https://files.pythonhosted.org/packages/95/47/2d0564e93d87bc48618360ddca232a2ca612bbdf53ce8465d45ca5ce14ee/regex-2026.7.19-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:40b34dd88658e4fedd2fddbf0275ac970d00614b731357f425722a3ed1983d11", size = 291832, upload-time = "2026-07-19T00:17:40.726Z" },
+    { url = "https://files.pythonhosted.org/packages/07/cd/42dfbabff3dfc9603c501c0e2e2c5adbb09d127b267bf5348de0af338c15/regex-2026.7.19-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c41c63992bf1874cebb6e7f56fd7d3c007924659a604ae3d90e427d40d4fd13", size = 796775, upload-time = "2026-07-19T00:17:42.382Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5d/f6a4839f2b934e3eed5973fd07f5929ee97d4c98939fb275ea23c274ee16/regex-2026.7.19-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d3372064506b94dd2c67c845f2db8062e9e9ba84d04e33cb96d7d33c11fe1ae", size = 865687, upload-time = "2026-07-19T00:17:44.185Z" },
+    { url = "https://files.pythonhosted.org/packages/14/b0/b47d6c36049bc59806a50bd4c86ced70bbe058d787f80281b1d7a9b0e024/regex-2026.7.19-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fce7760bf283405b2c7999cab3da4e72f7deca6396013115e3f7a955db9760da", size = 911962, upload-time = "2026-07-19T00:17:46.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/be/ff61f28f9273658cfe23acbbac5217221f6519960ed401e61dfdab12bc35/regex-2026.7.19-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0d702548d89d572b2929879bc883bb7a4c4709efafe4512cadee56c55c9bd15", size = 801817, upload-time = "2026-07-19T00:17:48.25Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/bb/8b4f7f26b333f9f79e1b453613c39bb4776f51d38ae66dd0ba31d6b354ca/regex-2026.7.19-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d446c6ac40bb6e05025ccee55b84d80fe9bf8e93010ffc4bb9484f13d498835f", size = 776908, upload-time = "2026-07-19T00:17:50.183Z" },
+    { url = "https://files.pythonhosted.org/packages/09/13/610110fc5921d380516d03c26b652555f08aa0d23ea78a771231873c3638/regex-2026.7.19-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4c3501bfa814ab07b5580741f9bf78dfdfe146a04057f82df9e2402d2a975939", size = 784426, upload-time = "2026-07-19T00:17:52.454Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/f5/1ef9e2a83a5947c57ebff0b377cb5727c3d5ec1992317a320d035cd0dbb6/regex-2026.7.19-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c4585c3e64b4f9e583b4d2683f18f5d5d872b3d71dcf24594b74ecc23602fa96", size = 860600, upload-time = "2026-07-19T00:17:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/02/073af33a3ec149241d11c80acea91e722aa0adbf05addd50f251c4fe89c3/regex-2026.7.19-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:571fde9741eb0ccde23dd4e0c1d50fbae910e901fa7e629faf39b2dda740d220", size = 765950, upload-time = "2026-07-19T00:17:56.041Z" },
+    { url = "https://files.pythonhosted.org/packages/81/a9/d1e9f819dc394a568ef370cd56cf25394e957a2235f8370f23b576e5a475/regex-2026.7.19-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:15b364b9b98d6d2fe1a85034c23a3180ff913f46caddc3895f6fd65186255ccc", size = 851794, upload-time = "2026-07-19T00:17:57.897Z" },
+    { url = "https://files.pythonhosted.org/packages/03/3a/8ae83eda7579feacdf984e71fb9e70635fb6f832eeddca58427ec4fca926/regex-2026.7.19-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ffd8893ccc1c2fce6e0d6ca402d716fe1b29db70c7132609a05955e31b2aa8f2", size = 789845, upload-time = "2026-07-19T00:17:59.97Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/c195cbfe5a75fdec64d8f6554fd15237b837919d2c61bdc141d7c807b08b/regex-2026.7.19-cp313-cp313-win32.whl", hash = "sha256:f0fa4fa9c3632d708742baf2282f2055c11d888a790362670a403cbf48a2c404", size = 267135, upload-time = "2026-07-19T00:18:01.958Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/80/a11de8404b7272b70acb45c1c05987cce60b45d5693da2e176f0e390d564/regex-2026.7.19-cp313-cp313-win_amd64.whl", hash = "sha256:d51ffd3427640fa2da6ade574ceba932f210ad095f65fcc450a2b0a0d454868e", size = 277747, upload-time = "2026-07-19T00:18:04.121Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/0f5c8eff1b4f1f3d83276d365fccecf666afcc7d947420943bf394d07adb/regex-2026.7.19-cp313-cp313-win_arm64.whl", hash = "sha256:c670fe7be5b6020b76bc6e8d2196074657e1327595bca93a389e1a76ab130ad8", size = 277129, upload-time = "2026-07-19T00:18:05.821Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4c/44b74742052cedda40f9ae469532a037112f7311a36669a891fba8984bb0/regex-2026.7.19-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db47b561c9afd884baa1f96f797c9ca369872c4b65912bc691cfa99e68340af2", size = 501134, upload-time = "2026-07-19T00:18:07.567Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/45/bbd038b5e39ee5613a5a689290145b40058cc152c41de9cc23639d2b9734/regex-2026.7.19-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:65dcd28d3eba2ab7c2fd906485cc301392b47cc2234790d27d4e4814e02cdfda", size = 299418, upload-time = "2026-07-19T00:18:09.38Z" },
+    { url = "https://files.pythonhosted.org/packages/65/38/c5bde94b4cedfd5850d64c3f08222d8e1600e84f6ee71d9b44b4b8163f74/regex-2026.7.19-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f2e7f8e2ab6c2922be02c7ec45185aa5bd771e2e57b95455ee343a44d8130dff", size = 294486, upload-time = "2026-07-19T00:18:11.188Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/6a/2f5e107cb26c960b781967178899daf2787a7ab151844ed3c01d6fc95474/regex-2026.7.19-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe31f28c94402043161876a258a9c6f757cb485905c7614ce8d6cd40e6b7bdc1", size = 811643, upload-time = "2026-07-19T00:18:12.975Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d4/a2f963406d7d73a62eed84ba05a258afb6cad1b21aa4517443ce40506b78/regex-2026.7.19-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f8f6fa298bb4f7f58a33334406218ba74716e68feddf5e4e54cd5d8082705abf", size = 871081, upload-time = "2026-07-19T00:18:14.733Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a3/44be546340bedb15f13063f5e7fe16793ea4d9ea2e805d09bd174ac27724/regex-2026.7.19-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cc1b2440423a851fad781309dd87843868f4f66a6bcd1ddb9225cf4ec2c84732", size = 917372, upload-time = "2026-07-19T00:18:16.724Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f6/e0870b0fd2a40dba0074e4b76e514b21313d37946c9248453e34ec43923e/regex-2026.7.19-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ac59a0900474a52b7c04af8196affc22bd9842acb0950df12f7b813e983609a", size = 816089, upload-time = "2026-07-19T00:18:18.617Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/27/957e8e22690ad6634572b39b71f130a6105f4d0718bb16849eac00fff147/regex-2026.7.19-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4896db1f4ce0576765b8272aa922df324e0f5b9bb2c3d03044ff32a7234a9aba", size = 785206, upload-time = "2026-07-19T00:18:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a4/186e410941e731037c01166069ab86da9f65e8f8110c18009ccf4bd623ee/regex-2026.7.19-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4e6883a021db30511d9fb8cfb0f222ce1f2c369f7d4d8b0448f449a93ba0bdfc", size = 800431, upload-time = "2026-07-19T00:18:22.716Z" },
+    { url = "https://files.pythonhosted.org/packages/73/9f/e4e10e023d291d64a33e246610b724493bf1ce98e0e59c9b7c837e5acfb7/regex-2026.7.19-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:09523a592938aa9f587fb74467c63ff0cf88fc3df14c82ab0f0517dcf76aaa62", size = 864906, upload-time = "2026-07-19T00:18:24.772Z" },
+    { url = "https://files.pythonhosted.org/packages/24/57/ccb20b6be5f1f52a053d1ba2a8f7a077edb9d918248b8490d7506c6832b3/regex-2026.7.19-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:1ebac3474b8589fce2f9b225b650afd61448f7c73a5d0255a10cc6366471aed1", size = 773559, upload-time = "2026-07-19T00:18:27.008Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/82/f3b263cf8fad927dc102891da8502e718b7ff9d19af7a2a07c03865d7188/regex-2026.7.19-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:4a0530bb1b8c1c985e7e2122e2b4d3aedd8a3c21c6bfddae6767c4405668b56e", size = 857739, upload-time = "2026-07-19T00:18:29.107Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2e/1687bd1b6c2aed5e672ccf845fc11557821fe7366d921b50889ea5ce57bf/regex-2026.7.19-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2ef7eeb108c47ce7bcc9513e51bcb1bf57e8f483d52fce68a8642e3527141ae0", size = 804522, upload-time = "2026-07-19T00:18:31.362Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7c/cc4e7655181b2d9235b704f2c5e19d8eff002bbc437bae59baee0e381aca/regex-2026.7.19-cp313-cp313t-win32.whl", hash = "sha256:64b6ca7391a1395c2638dd5c7456d67bea44fc6c5e8e92c5dc8aa6a8f23292b4", size = 269141, upload-time = "2026-07-19T00:18:33.479Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/14/961b4c7b05a2391c32dbc85e27773076671ef8f97f36cec70fe414734c02/regex-2026.7.19-cp313-cp313t-win_amd64.whl", hash = "sha256:f04b9f56b0e0614c0126be12c2c2d9f8850c1e57af302bd0a63bed379d4af974", size = 280036, upload-time = "2026-07-19T00:18:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/67/795644550d788ddbb6dc458c95895f8009978ea6d6ea76b005eb3f45e8c9/regex-2026.7.19-cp313-cp313t-win_arm64.whl", hash = "sha256:fcee38cd8e5089d6d4f048ba1233b3ad76e5954f545382180889112ff5cb712d", size = 279394, upload-time = "2026-07-19T00:18:37.454Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/25/0c4c452f8ef3efe456745b2f33195f5904b573fb4c2ff3f0cb9ec188461e/regex-2026.7.19-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:a81758ed242b861b72e778ba34d41366441a2e10b16b472784c88da2dea7e2dd", size = 496750, upload-time = "2026-07-19T00:18:39.633Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9e/b70ca6c1704f6c7cd32a9e143c86cc5968d10981eca284bad670c245ea7d/regex-2026.7.19-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4aa5435cdb3eb6f55fe98a171b05e3fbcd95fadaa4aa32acf62afd9b0cfdbcac", size = 297093, upload-time = "2026-07-19T00:18:41.583Z" },
+    { url = "https://files.pythonhosted.org/packages/87/74/0b692da2520d51fbff19c88b83d97e4c702909dd02386c585998b7e2dbed/regex-2026.7.19-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:60be8693a1dadc210bbcbc0db3e26da5f7d01d1d5a3da594e99b4fa42df404f5", size = 292043, upload-time = "2026-07-19T00:18:43.347Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a7/1d478e614016045a33feae57446215f9fd65b665a5ceb2f891fb3183bc52/regex-2026.7.19-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d19662dbedbe783d323196312d38f5ba53cf56296378252171985da6899887d3", size = 797214, upload-time = "2026-07-19T00:18:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ae/11b9c9411d92c30e3d2db32df5a31133e4a99a8fc397a604fd08f6c4bffb/regex-2026.7.19-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d15df07081d91b76ff20d43f94592ee110330152d617b730fdbe5ef9fb680053", size = 866433, upload-time = "2026-07-19T00:18:47.315Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/62/2b2efc4992f91d6d204b24c647c9f9412e85379d92b7c0ab9fdae622327e/regex-2026.7.19-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:56ad4d9f77df871a99e25c37091052a02528ec0eb059de928ee33956b854b45b", size = 911360, upload-time = "2026-07-19T00:18:49.588Z" },
+    { url = "https://files.pythonhosted.org/packages/14/71/986ceea9aa3da548bf1357cad89b63915ec6d21ec957c8113b29ece567df/regex-2026.7.19-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7322ec6cc9fba9d49ab888bb82d67ac5625627aa168f0165139b17018df3fb8a", size = 801275, upload-time = "2026-07-19T00:18:51.767Z" },
+    { url = "https://files.pythonhosted.org/packages/15/be/ce9d9534b2cda96eab32c548261224b9b4e220a4126f098f60f42ae7b4cd/regex-2026.7.19-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9c7472192ebfad53a6be7c4a8bfb2d64b81c0e93a1fc8c57e1dd0b638297b5d1", size = 777131, upload-time = "2026-07-19T00:18:54.053Z" },
+    { url = "https://files.pythonhosted.org/packages/61/2b/58b5c710f2c3929515a25f3a1ca0dad0dcd4518d4fff3cf23bc7adb8dcd2/regex-2026.7.19-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c10b82c2634df08dfb13b1f04e38fe310d086ee092f4f69c0c8da234251e556e", size = 785020, upload-time = "2026-07-19T00:18:56.579Z" },
+    { url = "https://files.pythonhosted.org/packages/84/03/5fe091935b74f15fe0f97998c215cae418d1c0413f6258c7d4d2e83aa37f/regex-2026.7.19-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:17ed5692f6acc4183e98331101a5f9e4f64d72fe58b753da4d444a2c77d05b12", size = 861263, upload-time = "2026-07-19T00:18:58.64Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/fa/d60bf82e10841eef62a9e32aac401468f05fddfbcb2942e342b1ba3d2433/regex-2026.7.19-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:22a992de9a0d91bda927bf02b94351d737a0302905432c88a53de7c4b9ce62e2", size = 766199, upload-time = "2026-07-19T00:19:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/5d/11e64d151b0662b81d6bf644c74dc118d461df85bdf2577fadbbf751788a/regex-2026.7.19-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:618a0aed532be87294c4477b0481f3aa0f1520f4014a4374dd4cf789b4cd2c97", size = 851317, upload-time = "2026-07-19T00:19:03.015Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/34/532efb87488d90807bae6a443d357ee5e2728a478c597619c8aaa17cc0bd/regex-2026.7.19-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ce9e679f776649746729b6c86382da519ef649c8e34cc41df0d2e5e0f6c36d4", size = 789557, upload-time = "2026-07-19T00:19:05.338Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/90/3a8d5ca977171ec3ae21a71207d2228b2663bde14d7f7ef0e6363ecf9290/regex-2026.7.19-cp314-cp314-win32.whl", hash = "sha256:73f272fba87b8ccfe70a137d02a54af386f6d27aa509fbffdd978f5947aae1aa", size = 272531, upload-time = "2026-07-19T00:19:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e1/8862885e70409de70e8c005f57fb2e7be8d9ef0317250d60f4c9660a300d/regex-2026.7.19-cp314-cp314-win_amd64.whl", hash = "sha256:d721e53758b2cca74990185eb0671dd466d7a388a1a45d0c6f4c13cef41a68ac", size = 280831, upload-time = "2026-07-19T00:19:09.46Z" },
+    { url = "https://files.pythonhosted.org/packages/08/82/2693e53e29f9104d9de95d37ce4dd826bd32d5f9c0085d3aa6ac042675c4/regex-2026.7.19-cp314-cp314-win_arm64.whl", hash = "sha256:65fa6cb38ed5e9c3637e68e544f598b39c3b86b808ed0627a67b68320384b459", size = 281099, upload-time = "2026-07-19T00:19:11.398Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b7/9a01aa16461a18cde9d7b9c3ab21e501db2ce33725f53014342b91df2b0a/regex-2026.7.19-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:5a2721c8720e2cb3c209925dfb9200199b4b07361c9e01d321719404b21458b3", size = 501121, upload-time = "2026-07-19T00:19:13.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/5e/bbaeca815dc9191c424c94a4fdc5c87c75748a64a6271821212ebdd4e1a3/regex-2026.7.19-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:199535629f25caf89698039af3d1ad5fcae7f933e2112c73f1cdf49165c99518", size = 299415, upload-time = "2026-07-19T00:19:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d6/0dd1a321afaab95eb7ff44aa0f637301786f1dc71c6b797b9ed236ed8890/regex-2026.7.19-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9b60d7814174f059e5de4ab98271cc5ba9259cfea55273a81544dceea32dc8d9", size = 294483, upload-time = "2026-07-19T00:19:17.879Z" },
+    { url = "https://files.pythonhosted.org/packages/92/5f/40bacf91d0904f812e13bbbab3864604c463eced8afdc54aeaa50492ea95/regex-2026.7.19-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dbece16025afda5e3031af0c4059207e61dcf73ef13af844964f57f387d1c435", size = 811833, upload-time = "2026-07-19T00:19:20.102Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/4902744261f775aeede8b5627314b38482da29cf49a57b66a6fb753246c5/regex-2026.7.19-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d24ecb4f5e009ea0bd275ee37ad9953b32005e2e5e60f8bbae16da0dbbf0d3a0", size = 871270, upload-time = "2026-07-19T00:19:22.365Z" },
+    { url = "https://files.pythonhosted.org/packages/16/70/6980c9be6bf21c0a60ed3e0aea39cf419ecf3b08d1d9947bc56e196ef186/regex-2026.7.19-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8cae6fd77a5b72dae505084b1a2ee0360139faf72fedbab667cd7cc65aae7a6a", size = 917534, upload-time = "2026-07-19T00:19:24.529Z" },
+    { url = "https://files.pythonhosted.org/packages/52/92/8b2bd872782ce8c42691e39acb38eb8efe014e5ddb78ad7d943d6f197ce9/regex-2026.7.19-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9724e6cb5e478cd7d8cabf027826178739cb18cf0e117d0e32814d479fa02276", size = 816135, upload-time = "2026-07-19T00:19:26.919Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2d/33a602f657bdc4041f17d79f92ab18261d255d91a06117a6e29df023e5e2/regex-2026.7.19-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:572fc57b0009c735ee56c175ea021b637a15551a312f56734277f923d6fd0f6c", size = 785492, upload-time = "2026-07-19T00:19:29.192Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/36/0987cf4cb271680064a70d24a475873775a151d0b7058698a006cb0cae4a/regex-2026.7.19-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:20568e182eb82d39a6bf7cff3fd58566f14c75c6f74b2c8c96537eecf9010e3a", size = 800658, upload-time = "2026-07-19T00:19:31.392Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/24/c14f31c135e1ba55fa4f9a58ca98d0842512bf6188230763c31c8f449e3b/regex-2026.7.19-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:1d58561843f0ff7dc78b4c28b5e2dc388f3eff94ebc8a232a3adba961fc00009", size = 865073, upload-time = "2026-07-19T00:19:33.485Z" },
+    { url = "https://files.pythonhosted.org/packages/14/85/181a12211f22469f24d2de1ebddfe397d2396e2c29013b9a58134a91069a/regex-2026.7.19-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:61bb1bd45520aacd56dd80943bd34991fb5350afdd1f36f2282230fd5154a218", size = 773684, upload-time = "2026-07-19T00:19:35.599Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/bd1a0c1a62251366f8d21f41b1ea3c76994962071b8b6ea42f72d505c0f0/regex-2026.7.19-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:cd3584591ea4429026cdb931b054342c2bcf189b44ff367f8d5c15bc092a2966", size = 857769, upload-time = "2026-07-19T00:19:37.738Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/4f/f7e2dad6756b2fe1fe75dd90a628c3b45f249d39f948dd90cd2476325417/regex-2026.7.19-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cc26a66e212fa5d6c6170c3a40d99d888db3020c6fdab1523250d4341382e44", size = 804546, upload-time = "2026-07-19T00:19:40.229Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d7/01d31d5bdb09bc026fab77f59a371fdf8f9b292e4810546c56182ca70498/regex-2026.7.19-cp314-cp314t-win32.whl", hash = "sha256:2c4e61e2e1be56f63ec3cc618aa9e0de81ef6f43d177205451840022e24f5b78", size = 274526, upload-time = "2026-07-19T00:19:42.398Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0e/cea4ce73bc0a8247a0748228ae6669984c7e1f8134b6fa66e59c0572e0ea/regex-2026.7.19-cp314-cp314t-win_amd64.whl", hash = "sha256:c639ea314df70a7b2811e8020448c75af8c9445f5a60f8a4ced81c306a9380c2", size = 283763, upload-time = "2026-07-19T00:19:44.644Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b6/26e41975febae63b7a6e3e02f32cff6cff2e4f10d19c929082f56aebf7c6/regex-2026.7.19-cp314-cp314t-win_arm64.whl", hash = "sha256:9a15e785f244f3e07847b984ce8773fc3da10a9f3c131cc49a4c5b4d672b4547", size = 283451, upload-time = "2026-07-19T00:19:46.639Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/e1/4508a569211b35599016e84ba65c1a992b7a4004b4b6c4bea02a851cba1b/ruff-0.16.2.tar.gz", hash = "sha256:c3d7828d12e8927a6fc65fe38e2c2541b9e762d360a1786d752cb1b8883b3c9c", size = 4885811, upload-time = "2026-08-07T13:31:01.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/57/db19951540f98859c956b50bdb4d31089b4d91e9f15e2968e7d5193806d5/ruff-0.16.2-py3-none-linux_armv6l.whl", hash = "sha256:3c8de4cf2181f01d57946d87d777aa52916976fc09942aed89938fab5e013318", size = 10847925, upload-time = "2026-08-07T13:30:14.468Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/995fe85a8470d3e391ac0f7fa8054bb454eaf33ee138196d6172ed1079c0/ruff-0.16.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a48cc05c6fbc811ca81b5d7ba95375affea6582d1b8024e455e41afbbf55344", size = 11072662, upload-time = "2026-08-07T13:30:18.143Z" },
+    { url = "https://files.pythonhosted.org/packages/32/53/370d767c61c71a971a4ace36703a7ecd8c393956349a7325d7fab2b56827/ruff-0.16.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2c0d14fcbb26c91f0f867a6dc9bd71bbc30b1b6151829c884f23faeab2e5700", size = 10566771, upload-time = "2026-08-07T13:30:20.899Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d6/9d96948caf5a632be62d62202d5ec914d6856f204fd79eb036e5915e79ea/ruff-0.16.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:335c621622c4650330be50842561c6586ac6971bb8ab5407fe34dcc9efb16bbe", size = 10975825, upload-time = "2026-08-07T13:30:23.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/92/ea87129b3414acb0b5770563779c51804d37ac67675c7ba35447ddb14773/ruff-0.16.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20e66910f2c37cc753f9ef6580c914a621b80c4fa3549d3e3521e29d0f5bfc3f", size = 10649437, upload-time = "2026-08-07T13:30:26.097Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/43/f8f291dcd4af5bb7872b74fdfa41a7cd7c856ca1d4069670971cf1b9f5cb/ruff-0.16.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7e36fbfba65510548156902bcf1350a979a958ce0347ce0f90d73894036b39f", size = 11446761, upload-time = "2026-08-07T13:30:28.752Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4a/ef991fb2fcf516ab71f0808adcdd8da5e18c8cde447f4ceaf5f47a5132a5/ruff-0.16.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0eab35f80df8f134aae5d1630e751901321d317cc8e50dc39e36fa3ed34cd12", size = 12336364, upload-time = "2026-08-07T13:30:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/24/f615e74f307e6ca0e56a482872477b856c70d530aa356abfb6dfe5ca8a80/ruff-0.16.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ea8c0594feb894e89c8c61ab9c103d38b0ea72dfde6c594107147ca31b1140", size = 11630720, upload-time = "2026-08-07T13:30:34.426Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d3/8ef50149e8412a77f7ab409efdef0e2b23803707a3863da4fc64cb23d459/ruff-0.16.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab3d62dde0b19facdd632008cc4827fc28ada7736c6bd35ab6f1050f0bfed53f", size = 11466130, upload-time = "2026-08-07T13:30:36.958Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a7/a19334985c4dea8c381981fa252cd854c7ee52dc4b1686dc16f4a911c702/ruff-0.16.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e43e1f5b8388da9eca1b9e88328d47a5cec794633ccf6f7484ac2dd15eee92c0", size = 11523634, upload-time = "2026-08-07T13:30:39.822Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6c/96d192b0e742412ceda08c0a50f9669b253dde9fd6a60ea1a10c9fa79a63/ruff-0.16.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c24788a980581e1d7ea3a0cbe4344c4fbeb0a6a9b1f4713aa46bb104f8294690", size = 10949807, upload-time = "2026-08-07T13:30:42.745Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/51/e26599ceca11e79ee255c7df515995561edf87e9ca1893284e44d98f5a86/ruff-0.16.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:81806b08329130005dd4a8a8394a0c9da8c6f4cafb16ba438d2a2ee6a18bedf1", size = 10646891, upload-time = "2026-08-07T13:30:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/68/01/800c4b1f97bc8d7c6029e06b1f20473a3cf1e13c4933d8f3342add83fc55/ruff-0.16.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4ce4e02bad779bef557f541a1b31f20d6abeae1cc05ed1b1ac019d4ffd1044c8", size = 11162063, upload-time = "2026-08-07T13:30:48.131Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d0/1477ea50fc5a0d4b0b71d1d63d50770bdd794d90b43e37a7618e63ec9894/ruff-0.16.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e0422abdf70070255fc4073ce9dfc814cc03db577013761ddd09bc1e4a9a4fbd", size = 11556038, upload-time = "2026-08-07T13:30:50.686Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/76/a7776f32048d991e16d4fa8ff91790b877342d3596cc3ed04acdbf1aaedc/ruff-0.16.2-py3-none-win32.whl", hash = "sha256:bf3a63d78fb39f4bf5ac8ae52051c5520505301abe19ba4e204c453b3f09bb0b", size = 10872850, upload-time = "2026-08-07T13:30:53.471Z" },
+    { url = "https://files.pythonhosted.org/packages/00/0d/929c800d920e61397d82a01b60bffc68da3052c17d31de59efaad2e4ed75/ruff-0.16.2-py3-none-win_amd64.whl", hash = "sha256:bcabe2f6d0fc7819f1431793005af4e4de7371927d037345bf941252b195b9fa", size = 12023338, upload-time = "2026-08-07T13:30:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6c/93e26c22c5f78ff87363e07da49c84955affbeb1098bd1936bf3b3f293bf/ruff-0.16.2-py3-none-win_arm64.whl", hash = "sha256:d614e95cedf38a2053fd351c55b103ba30d017d61688fdbfd40ee0412852a99f", size = 11374065, upload-time = "2026-08-07T13:30:58.775Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260724"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893, upload-time = "2026-07-24T04:58:43.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312, upload-time = "2026-07-24T04:58:42.486Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/bc/4eae18cd40c65798a16267572ba346c11f599d44b01603dbd843342042bc/typing_inspection-0.4.3.tar.gz", hash = "sha256:c5f9ec1530b5c1e2c9bc34a84d9a3466ed1b2f3f2fa9f901368d9c5596210e4d", size = 76711, upload-time = "2026-08-10T09:39:18.063Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/f7/7a3935abdebd5cf18705a5f0335dd6a3a18bef3baa7cb9edc3b6b9922cc8/typing_inspection-0.4.3-py3-none-any.whl", hash = "sha256:5f42b23858a91e0b4ef521f5418f03a0da3c9216fd2995ef5e73463100e676cd", size = 14693, upload-time = "2026-08-10T09:39:16.693Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]


### PR DESCRIPTION
## Summary

- Add an evidence-first RSS, website, and public API collection pipeline.
- Add Alibaba and DeepSeek model routing with strict structured output, bounded fallback, token and cost budgets, and audit artifacts.
- Add deterministic deduplication, selection, Markdown assembly, and idempotent GitHub Issue publication.
- Add reusable Pages deployment plus 04:20, 05:05, and 05:45 Asia/Shanghai recovery schedules.
- Preserve existing GitHub Issues, Zola, Pages, and RSS assets while restricting bot-authored content to marked Daily issues.
- Add operations and research documentation, CI, and a 20-case model evaluation dataset.

## Verification

- 36 pytest tests pass.
- Ruff, Mypy, and Pyright pass.
- actionlint passes for all workflows.
- Python package and bytecode builds pass.
- Dependency audit reports no known vulnerabilities.
- Staging CI and Pages deployment pass.
- Staging website and RSS return HTTP 200; browser console has no errors.
- Public-source smoke collected 170 items with 4/4 Tier A sources healthy; arXiv rate limiting was surfaced as a Tier B source failure.

## Security

- API keys are read only from environment variables or GitHub Actions Secrets.
- Previously exposed keys were not used.
- GitHub tokens are no longer passed through process arguments.
- Live provider smoke and scheduled publication remain disabled until replacement keys are configured.

## Remaining rollout gate

Replacement DASHSCOPE_API_KEY, DASHSCOPE_BASE_URL, and DEEPSEEK_API_KEY must be configured outside chat before live provider smoke, model benchmarking, and schedule activation.