### PR TITLE
fix: keep newest daily first in RSS

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,7 +118,7 @@ def generate_rss_feed(repo, feed_filename, me):
     fg.link(href=f"{SITE_BASE_URL}/{feed_filename}", rel="self")
     fg.language("zh-CN")
 
-    count = 0
+    trusted_issues = []
     for issue in repo.get_issues(state="open", sort="created", direction="desc"):
         if not is_trusted_issue(issue, me):
             continue
@@ -126,6 +126,12 @@ def generate_rss_feed(repo, feed_filename, me):
         if any(label in IGNORE_LABELS for label in labels):
             continue
 
+        trusted_issues.append(issue)
+        if len(trusted_issues) >= 30:
+            break
+
+    # FeedGenerator prepends entries, so add oldest first to emit newest first.
+    for issue in reversed(trusted_issues):
         body = issue.body or ""
         html_body = marko(body)
         summary = re.sub(r"<[^>]+>", "", html_body)[:RSS_SUMMARY_MAX_CHARS]
@@ -138,10 +144,6 @@ def generate_rss_feed(repo, feed_filename, me):
         fe.updated(issue.updated_at.replace(tzinfo=UTC))
         fe.summary(summary)
         fe.content(html_body, type="html")
-
-        count += 1
-        if count >= 30:
-            break
 
     fg.rss_file(feed_filename, pretty=True)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,40 @@
+import runpy
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any, cast
+
+import feedparser
+
+generate_rss_feed = cast(Callable[..., None], runpy.run_path("main.py")["generate_rss_feed"])
+
+
+class FakeRepo:
+    def __init__(self, issues: list[SimpleNamespace]) -> None:
+        self.issues = issues
+
+    def get_issues(self, **kwargs: Any) -> list[SimpleNamespace]:
+        return self.issues
+
+
+def _issue(number: int, created_at: datetime) -> SimpleNamespace:
+    return SimpleNamespace(
+        number=number,
+        title=f"2026-08-{number:02d}",
+        body="digest",
+        html_url=f"https://github.com/wjy9902/ai-daily/issues/{number}",
+        created_at=created_at,
+        updated_at=created_at,
+        labels=[],
+        user=SimpleNamespace(login="wjy9902"),
+    )
+
+
+def test_rss_emits_newest_issue_first(tmp_path) -> None:
+    now = datetime(2026, 8, 12, tzinfo=UTC)
+    issues = [_issue(12, now), _issue(11, now - timedelta(days=1))]
+    rss_path = tmp_path / "rss.xml"
+    generate_rss_feed(FakeRepo(issues), str(rss_path), "wjy9902")
+    feed = feedparser.parse(rss_path.read_bytes())
+    assert feed.entries[0].title == "2026-08-12"
+    assert feed.entries[0].link.endswith("/issue-12/")


### PR DESCRIPTION
## Summary

FeedGenerator prepends entries. The existing newest-to-oldest loop therefore emitted the oldest selected issue first, causing the RSS freshness verifier to fail even when today’s page existed.

This change collects the newest 30 trusted issues, feeds them to FeedGenerator oldest-first, and adds a regression test proving the newest Issue is the first RSS item.

## Verification

- 37 pytest tests pass.
- Ruff passes.
- Production browser check reproduced the stale ordering before this fix.
- Staging Pages will be rechecked after CI deployment.