### PR TITLE
fix: use object schema for judge output

### DIFF
--- a/src/ai_daily/content.py
+++ b/src/ai_daily/content.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import json
 from collections import defaultdict
 
-from pydantic import RootModel
+from pydantic import BaseModel
 
 from ai_daily.model_gateway import ModelGateway
 from ai_daily.models import DraftItem, Event, Evidence, EvidenceBundle, JudgeDecision
 
 
-class JudgeBatch(RootModel[list[JudgeDecision]]):
-    pass
+class JudgeBatch(BaseModel):
+    decisions: list[JudgeDecision]
 
 
 def evidence_bundle(event: Event) -> EvidenceBundle:
@@ -39,18 +39,18 @@ async def judge_events(gateway: ModelGateway, events: list[Event]) -> list[Judge
         ),
         prompt=json.dumps(bundles, ensure_ascii=False),
     )
-    by_event = {decision.event_id: decision for decision in result.root}
+    by_event = {decision.event_id: decision for decision in result.decisions}
     expected = {event.event_id for event in events}
-    if set(by_event) != expected or len(result.root) != len(events):
+    if set(by_event) != expected or len(result.decisions) != len(events):
         raise ValueError("judge output does not cover every event exactly once")
     allowed = {
         bundle.event_id: {evidence.evidence_id for evidence in bundle.evidence}
         for bundle in map(evidence_bundle, events)
     }
-    for decision in result.root:
+    for decision in result.decisions:
         if not set(decision.evidence_ids) <= allowed[decision.event_id]:
             raise ValueError("judge referenced unknown evidence")
-    return result.root
+    return result.decisions
 
 
 async def draft_selected(

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -2,6 +2,8 @@ from datetime import UTC, datetime
 from typing import Any
 
 from pydantic import BaseModel
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
 
 from ai_daily.content import JudgeBatch, draft_selected, judge_events
 from ai_daily.models import DraftItem, Event, JudgeDecision, RawItem, SourceTier
@@ -32,7 +34,7 @@ class FakeGateway:
     ) -> Any:
         if output_type is JudgeBatch:
             return JudgeBatch(
-                root=[
+                decisions=[
                     JudgeDecision(
                         event_id="event-1",
                         selected=True,
@@ -89,7 +91,7 @@ class DuplicateJudgeGateway(FakeGateway):
     ) -> Any:
         value = await super().generate(role, output_type, instructions, prompt)
         if isinstance(value, JudgeBatch):
-            return JudgeBatch(root=[value.root[0], value.root[0]])
+            return JudgeBatch(decisions=[value.decisions[0], value.decisions[0]])
         return value
 
 
@@ -100,3 +102,8 @@ async def test_judge_must_return_each_event_exactly_once() -> None:
         assert "exactly once" in str(error)
     else:
         raise AssertionError("duplicate judge decision was accepted")
+
+
+def test_judge_batch_is_valid_structured_tool_output() -> None:
+    assert JudgeBatch.model_json_schema()["type"] == "object"
+    Agent(TestModel(), output_type=JudgeBatch)


### PR DESCRIPTION
## Summary
- Wrap judge decisions in a top-level object accepted by Pydantic AI structured tool output.
- Preserve exact event coverage and evidence-ID validation.

## Verification
- Ruff passed.
- Mypy passed.
- Pyright passed.
- Pytest: 38 passed.
- Regression test constructs a real Pydantic AI Agent with the judge schema.

## Staging evidence
- Prior dry-run failed deterministically during Agent construction with `Schema must be an object`.
- Production schedule remains disabled pending a successful staging live run.