### PR TITLE
fix: disable thinking for Alibaba tool output

### DIFF
--- a/src/ai_daily/model_gateway.py
+++ b/src/ai_daily/model_gateway.py
@@ -71,11 +71,7 @@ class ModelGateway:
                 )
                 result = await agent.run(
                     prompt,
-                    model_settings=ModelSettings(
-                        temperature=endpoint.temperature,
-                        max_tokens=endpoint.max_output_tokens,
-                        timeout=endpoint.timeout_seconds,
-                    ),
+                    model_settings=self._model_settings(endpoint),
                     usage_limits=UsageLimits(
                         request_limit=1,
                         input_tokens_limit=self.config.budget.input_token_limit,
@@ -115,6 +111,16 @@ class ModelGateway:
                     continue
                 raise ModelInvocationFailed(self._safe_error(error)) from error
         raise AssertionError("unreachable")
+
+    @staticmethod
+    def _model_settings(endpoint: ModelEndpoint) -> ModelSettings:
+        extra_body = {"enable_thinking": False} if endpoint.provider == "alibaba" else None
+        return ModelSettings(
+            temperature=endpoint.temperature,
+            max_tokens=endpoint.max_output_tokens,
+            timeout=endpoint.timeout_seconds,
+            extra_body=extra_body,
+        )
 
     def _build_model(self, endpoint: ModelEndpoint) -> OpenAIChatModel:
         if endpoint.provider == "alibaba":

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -24,6 +24,15 @@ def test_provider_requires_environment_secrets() -> None:
         raise AssertionError("missing secrets were accepted")
 
 
+def test_alibaba_structured_output_disables_thinking_mode() -> None:
+    gateway = ModelGateway(load_config().models, Secrets())
+    alibaba = gateway.config.roles["judge"].primary
+    deepseek = gateway.config.roles["judge"].fallback
+
+    assert gateway._model_settings(alibaba)["extra_body"] == {"enable_thinking": False}
+    assert gateway._model_settings(deepseek)["extra_body"] is None
+
+
 def test_fallback_audit_preserves_requested_model() -> None:
     gateway = ModelGateway(load_config().models, Secrets(), clock=lambda: 1.0)
     role = gateway.config.roles["judge"]


### PR DESCRIPTION
## Summary
- Disable Alibaba thinking mode for structured tool-output requests.
- Keep DeepSeek request settings unchanged.

## Verification
- Ruff passed.
- Mypy passed.
- Pyright passed.
- Pytest: 39 passed.
- Staging reproduced the provider error before this fix.