### PR TITLE
fix: batch judge candidates for strict output

### DIFF
--- a/src/ai_daily/content.py
+++ b/src/ai_daily/content.py
@@ -13,6 +13,9 @@ class JudgeBatch(BaseModel):
     decisions: list[JudgeDecision]
 
 
+JUDGE_BATCH_SIZE = 10
+
+
 def evidence_bundle(event: Event) -> EvidenceBundle:
     evidence = [
         Evidence(
@@ -28,7 +31,15 @@ def evidence_bundle(event: Event) -> EvidenceBundle:
 
 
 async def judge_events(gateway: ModelGateway, events: list[Event]) -> list[JudgeDecision]:
-    bundles = [evidence_bundle(event).model_dump(mode="json") for event in events]
+    decisions = []
+    for start in range(0, len(events), JUDGE_BATCH_SIZE):
+        batch = events[start : start + JUDGE_BATCH_SIZE]
+        decisions.extend(await _judge_batch(gateway, batch))
+    return decisions
+
+
+async def _judge_batch(gateway: ModelGateway, events: list[Event]) -> list[JudgeDecision]:
+    bundles = [evidence_bundle(event) for event in events]
     result = await gateway.generate(
         "judge",
         JudgeBatch,
@@ -37,20 +48,23 @@ async def judge_events(gateway: ModelGateway, events: list[Event]) -> list[Judge
             "每个 event_id 必须恰好返回一个决定，evidence_ids 只能使用输入值。"
             "优先会改变技术或产品行动的官方发布、重要研究和高质量开源项目。"
         ),
-        prompt=json.dumps(bundles, ensure_ascii=False),
+        prompt=json.dumps(
+            [bundle.model_dump(mode="json") for bundle in bundles], ensure_ascii=False
+        ),
     )
-    by_event = {decision.event_id: decision for decision in result.decisions}
+    decisions = result.decisions
+    by_event = {decision.event_id: decision for decision in decisions}
     expected = {event.event_id for event in events}
-    if set(by_event) != expected or len(result.decisions) != len(events):
+    if set(by_event) != expected or len(decisions) != len(events):
         raise ValueError("judge output does not cover every event exactly once")
     allowed = {
         bundle.event_id: {evidence.evidence_id for evidence in bundle.evidence}
-        for bundle in map(evidence_bundle, events)
+        for bundle in bundles
     }
-    for decision in result.decisions:
+    for decision in decisions:
         if not set(decision.evidence_ids) <= allowed[decision.event_id]:
             raise ValueError("judge referenced unknown evidence")
-    return result.decisions
+    return decisions
 
 
 async def draft_selected(

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, datetime
 from typing import Any
 
@@ -29,21 +30,27 @@ def event() -> Event:
 
 
 class FakeGateway:
+    def __init__(self) -> None:
+        self.calls = 0
+
     async def generate(
         self, role: str, output_type: type[BaseModel], instructions: str, prompt: str
     ) -> Any:
         if output_type is JudgeBatch:
+            self.calls += 1
+            bundles = json.loads(prompt)
             return JudgeBatch(
                 decisions=[
                     JudgeDecision(
-                        event_id="event-1",
+                        event_id=bundle["event_id"],
                         selected=True,
                         category="模型与平台",
                         relevance=95,
                         confidence=0.9,
                         reason="Official material change",
-                        evidence_ids=["event-1-1"],
+                        evidence_ids=[bundle["evidence"][0]["evidence_id"]],
                     )
+                    for bundle in bundles
                 ]
             )
         return DraftItem(
@@ -107,3 +114,13 @@ async def test_judge_must_return_each_event_exactly_once() -> None:
 def test_judge_batch_is_valid_structured_tool_output() -> None:
     assert JudgeBatch.model_json_schema()["type"] == "object"
     Agent(TestModel(), output_type=JudgeBatch)
+
+
+async def test_judge_splits_large_candidate_sets_into_small_batches() -> None:
+    gateway = FakeGateway()
+    events = [event().model_copy(update={"event_id": f"event-{index}"}) for index in range(21)]
+
+    decisions = await judge_events(gateway, events)  # type: ignore[arg-type]
+
+    assert len(decisions) == 21
+    assert gateway.calls == 3


### PR DESCRIPTION
## Summary
- Split judge candidates into batches of 10 to reduce structured-output failure probability.
- Keep strict schema and evidence validation for every batch.
- Stay within the 30-request daily budget.

## Verification
- Ruff passed.
- Mypy passed.
- Pyright passed.
- Pytest: 40 passed.
- Staging reproduced a single-field typo in a 24-item response before this fix.