### PR TITLE
fix: restore Pages build with Zola 0.23

### DIFF
--- a/.github/workflows/generate_site.yml
+++ b/.github/workflows/generate_site.yml
@@ -52,7 +52,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       GITHUB_REPOSITORY_OWNER: ${{ github.repository_owner }}
       ISITE_VERSION: v0.2.4
-      ZOLA_VERSION: v0.20.0
+      ZOLA_VERSION: v0.23.3
+      EVEN_THEME_COMMIT: 56015feedb5b3d6a7b74c077568449892cf8b458
       USER: ${{ github.repository_owner }}
       REPO: ${{ github.event.repository.name }}
       BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
@@ -74,6 +75,7 @@ jobs:
           gh release download $ISITE_VERSION --repo kemingy/isite -p '*linux_amd64*' --output isite.tar.gz
           tar zxf isite.tar.gz && mv isite /usr/local/bin
           isite generate --user $USER --repo $REPO
+          git -C output/themes/even checkout --detach "$EVEN_THEME_COMMIT"
           gh release download $ZOLA_VERSION --repo getzola/zola -p '*x86_64-unknown-linux*' --output zola.tar.gz
           tar zxf zola.tar.gz && mv zola /usr/local/bin
           cp config.toml output/config.toml

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 base_url = "https://wjy9902.github.io/ai-daily/"
 title = "甲鱼AI日报"
+description = "每日 AI 前沿技术情报，由 AI 辅助创作"
 generate_feeds = true
 feed_filenames = ["rss.xml"]
 theme = "even"
@@ -14,8 +15,10 @@ even_menu = [
     {url = "/ai-daily/tags/top/", name = "Top"},
 ]
 [markdown]
-highlight_code = true
 render_emoji = true
+
+[markdown.highlighting]
+theme = "gruvbox-dark-medium"
 
 [link_checker]
 internal_level = "warn"

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -17,6 +17,17 @@ def test_site_workflow_is_reusable_and_locked() -> None:
     assert "requirements.txt" not in workflow
     assert "python main.py ${{ github.repository }}" in workflow
     assert "python main.py ${{ github.token }}" not in workflow
+    assert "ZOLA_VERSION: v0.23.3" in workflow
+    assert "EVEN_THEME_COMMIT: 56015feedb5b3d6a7b74c077568449892cf8b458" in workflow
+    assert 'git -C output/themes/even checkout --detach "$EVEN_THEME_COMMIT"' in workflow
+
+
+def test_zola_config_uses_current_highlighting_schema() -> None:
+    config = Path("config.toml").read_text()
+    assert 'description = "每日 AI 前沿技术情报，由 AI 辅助创作"' in config
+    assert "[markdown.highlighting]" in config
+    assert 'theme = "gruvbox-dark-medium"' in config
+    assert "highlight_code" not in config
 
 
 def test_recovery_does_not_call_model_when_issue_exists() -> None:


### PR DESCRIPTION
Root cause: kemingy/even moved to Tera 2 component syntax while the site workflow remained pinned to Zola 0.20. This pins Zola 0.23.3 and the compatible theme commit, migrates the highlighting config, adds the required site description, and adds workflow/config contract tests. Full local build generated issue-165 successfully; Ruff, Mypy, Pyright and 43 tests pass.