### PR TITLE
fix: select GNU Zola release asset

### DIFF
--- a/.github/workflows/generate_site.yml
+++ b/.github/workflows/generate_site.yml
@@ -76,7 +76,8 @@ jobs:
           tar zxf isite.tar.gz && mv isite /usr/local/bin
           isite generate --user $USER --repo $REPO
           git -C output/themes/even checkout --detach "$EVEN_THEME_COMMIT"
-          gh release download $ZOLA_VERSION --repo getzola/zola -p '*x86_64-unknown-linux*' --output zola.tar.gz
+          gh release download $ZOLA_VERSION --repo getzola/zola \
+            -p '*x86_64-unknown-linux-gnu*' --output zola.tar.gz
           tar zxf zola.tar.gz && mv zola /usr/local/bin
           cp config.toml output/config.toml
           mkdir -p output/static

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -20,6 +20,8 @@ def test_site_workflow_is_reusable_and_locked() -> None:
     assert "ZOLA_VERSION: v0.23.3" in workflow
     assert "EVEN_THEME_COMMIT: 56015feedb5b3d6a7b74c077568449892cf8b458" in workflow
     assert 'git -C output/themes/even checkout --detach "$EVEN_THEME_COMMIT"' in workflow
+    assert "*x86_64-unknown-linux-gnu*" in workflow
+    assert "'*x86_64-unknown-linux*'" not in workflow
 
 
 def test_zola_config_uses_current_highlighting_schema() -> None:


### PR DESCRIPTION
Zola 0.23.3 publishes both GNU and musl Linux archives. The previous wildcard matched both, so gh release download rejected --output. This selects the GNU asset exactly and adds regression assertions. The exact archive download, Ruff, Mypy, Pyright and 43 tests pass.