### PR TITLE
fix: bound persona analyst prompts

### DIFF
--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -203,8 +203,8 @@ class PersonaPipeline:
             {
                 "memory_id": memories[item].memory_id,
                 "kind": memories[item].kind.value,
-                "statement": _bounded_text(memories[item].statement, 350),
-                "source_context": _bounded_text(memories[item].source_context, 350),
+                "statement": _bounded_text(memories[item].statement, 260),
+                "source_context": _bounded_text(memories[item].source_context, 180),
             }
             for item in selection.memory_ids[:4]
         ]
@@ -388,16 +388,43 @@ def _planner_event_rows(snapshot: Any, event_ids: list[str]) -> list[dict[str, A
 def _analyst_event_row(snapshot: Any, selection: PlanSelection) -> dict[str, Any]:
     row = _event_rows(snapshot, [selection.event_id])[0]
     allowed = set(selection.evidence_ids[:3])
-    row["event"]["summary"] = _bounded_text(str(row["event"]["summary"]), 800)
-    row["evidence"]["evidence"] = [
+    event = row["event"]
+    evidence = [
         {
-            **item,
-            "excerpt": _bounded_text(str(item["excerpt"]), 1_600),
+            "evidence_id": item["evidence_id"],
+            "url": str(item["url"])[:500],
+            "title": str(item["title"])[:160],
+            "excerpt": _bounded_text(str(item["excerpt"]), 750),
+            "source": str(item["source"])[:120],
+            "source_time_kind": item["source_time_kind"],
         }
         for item in row["evidence"]["evidence"]
         if item["evidence_id"] in allowed
     ][:3]
-    return row
+    judge = row["judge"]
+    compact_judge = None
+    if judge is not None:
+        compact_judge = {
+            "event_id": judge["event_id"],
+            "category": judge["category"],
+            "relevance": judge["relevance"],
+            "confidence": judge["confidence"],
+            "reason": _bounded_text(str(judge["reason"]), 300),
+            "evidence_ids": judge["evidence_ids"][:3],
+        }
+    return {
+        "event": {
+            "event_id": event["event_id"],
+            "canonical_url": str(event["canonical_url"])[:500],
+            "title": str(event["title"])[:160],
+            "summary": _bounded_text(str(event["summary"]), 600),
+            "published_at": event["published_at"],
+            "source_time_kind": event["source_time_kind"],
+            "score": event["score"],
+        },
+        "evidence": {"event_id": selection.event_id, "evidence": evidence},
+        "judge": compact_judge,
+    }
 
 
 def _json_prompt(**payload: Any) -> str:

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -40,6 +40,8 @@ from ai_daily.persona_models import (
 )
 from ai_daily.persona_pipeline import (
     PersonaPipeline,
+    _analyst_event_row,
+    _json_prompt,
     _validate_critique,
     _validate_finalizer_changes,
 )
@@ -127,6 +129,70 @@ def _snapshot(layout: SiteLayout) -> UpstreamSnapshot:
     )
     write_artifact(layout.upstream_object_path(snapshot.publication_marker), snapshot)
     return snapshot
+
+
+def test_analyst_prompt_drops_nested_raw_items_and_stays_bounded() -> None:
+    event = factories.event(0)
+    raw = event.items[0].model_copy(update={"summary": "长原文。" * 2_500})
+    event = event.model_copy(
+        update={"summary": "事件摘要。" * 1_500, "items": [raw] * 8}
+    )
+    bundle = evidence_bundle(event)
+    evidence = bundle.evidence[0]
+    bundle = bundle.model_copy(
+        update={
+            "evidence": [
+                evidence.model_copy(
+                    update={
+                        "evidence_id": f"event-0-{index}",
+                        "excerpt": "可核验的证据句。" * 500,
+                    }
+                )
+                for index in range(1, 4)
+            ]
+        }
+    )
+    unsigned = UpstreamSnapshot(
+        target_date=TARGET,
+        publication_level=PublicationLevel.L0,
+        publication_marker="a" * 64,
+        events=[event],
+        evidence_bundles=[bundle],
+        decisions=[factories.judge_decision(0)],
+        editorial_plan=None,
+        snapshot_sha256="0" * 64,
+    )
+    selection = PlanSelection(
+        event_id="event-0",
+        grade="S",
+        importance_reason="这项变化影响 AI 产品决策。",
+        evidence_ids=["event-0-1", "event-0-2", "event-0-3"],
+    )
+
+    row = _analyst_event_row(unsigned, selection)
+    prompt = _json_prompt(
+        selection=selection.model_dump(mode="json"),
+        event=row,
+        memories=[
+            {
+                "memory_id": f"memory-{index}",
+                "kind": "experience",
+                "statement": "个人经验。" * 52,
+                "source_context": "来源背景。" * 36,
+            }
+            for index in range(4)
+        ],
+        baseline={
+            "event_id": "event-0",
+            "matched_event_id": "historical-event",
+            "baseline_evidence_ids": ["historical-evidence"],
+            "confidence": 0.9,
+            "reasoning": "同一实体的同一指标。" * 40,
+        },
+    )
+
+    assert "items" not in row["event"]
+    assert len(prompt) <= 10_000
 
 
 def _claim(claim_id: str, path: str, text: str) -> AnalysisClaim:


### PR DESCRIPTION
## Root cause
`_analyst_event_row` embedded the complete `Event.items` collection, including multi-kilobyte raw article summaries, after only truncating `Event.summary`. Today's five real analyst prompts were 11,293–17,252 characters and were correctly held by the 10,000-character gate.

## Fix
- emit a compact, allowlisted analyst event card without nested raw items
- keep up to 3 selected evidence excerpts and 4 bounded memories
- retain the 10,000-character fail-fast gate
- add a worst-shaped nested-item regression test

## Evidence
- same production snapshot after fix: 2,563–3,504 characters per analyst prompt
- `uv run pytest -q` — 481 passed
- `uv run ruff check .`
- `uv run mypy src`
- `git diff --check`
- targeted secret scan clean