### PR TITLE
fix: size persona token budget for concurrency

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -18,5 +18,8 @@ ai_disclosure: 本文由 AI 参与资料整理和初稿生成，并经过证据�
 budget:
   request_limit: 40
   input_token_limit: 500000
-  output_token_limit: 100000
+  # The persona gateway reserves the worst case before a call. Three concurrent
+  # 48k-output calls with one schema retry can reserve 288k even though actual
+  # usage is much lower. Keep tokens non-binding and let the ¥5 ceiling stop spend.
+  output_token_limit: 500000
   cost_cny_limit: 5.0

--- a/tests/test_budget_staging.py
+++ b/tests/test_budget_staging.py
@@ -25,6 +25,7 @@ from test_content import FakeGateway, event, plan
 from ai_daily.budget import BudgetLedger, BudgetStage, StageBudgetExceeded
 from ai_daily.config import load_config
 from ai_daily.content import draft_selected, judge_events, plan_digest
+from ai_daily.models import ModelRun
 
 
 class StageRecordingGateway(FakeGateway):  # type: ignore[misc]
@@ -122,6 +123,40 @@ def test_a_full_issue_fits_inside_each_stage_allowance() -> None:
             f"{stage.value} allows {available} requests but a single issue can "
             f"need {needed}; a normal day would degrade on budget alone"
         )
+
+
+def test_persona_budget_can_reserve_three_concurrent_analysts_after_planning() -> None:
+    config = load_config(Path("config"))
+    assert config.persona is not None
+    ledger = BudgetLedger(config.persona.budget)
+    planner = ModelRun(
+        role="persona_planner",
+        requested_provider="deepseek",
+        requested_model="deepseek-v4-pro",
+        actual_provider="deepseek",
+        actual_model="deepseek-v4-pro",
+        attempt=1,
+        status="ok",
+        latency_ms=1,
+        input_tokens=12_305,
+        output_tokens=23_663,
+        cost_cny=0.19,
+    )
+    ledger.record_requests(1, BudgetStage.PERSONA)
+    ledger.record(planner, BudgetStage.PERSONA)
+
+    for _ in range(config.persona.analyst_concurrency):
+        ledger.reserve(
+            BudgetStage.PERSONA,
+            2,
+            config.persona.max_call_cost_cny,
+            input_tokens=20_000,
+            output_tokens=96_000,
+        )
+
+    assert ledger.reserved_requests == 6
+    assert ledger.reserved_output_tokens == 288_000
+    assert ledger.remaining_cost() == pytest.approx(0.31)
 
 
 def test_stage_totals_are_reported_separately(tmp_path: Path) -> None:


### PR DESCRIPTION
## Root cause
The persona gateway reserves the worst-case output allowance before each call. Three concurrent analyst calls can reserve 288k output tokens after planning, so the previous 100k issue-level limit held a valid run before analyst execution.

## Fix
- raise the persona output-token ceiling to 500k while retaining the ¥5 cost cap as the spending brake
- add a regression test covering planner usage plus three concurrent analyst reservations

## Verification
- full pytest suite passed
- Ruff, mypy, diff check, and secret scan passed in the preceding verification run