### PR TITLE
fix: preserve persona retry headroom

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -6,7 +6,10 @@ constitution_path: config/persona/source-artifacts/editorial-constitution-v1.md
 candidate_limit: 30
 memory_limit: 16
 analyst_concurrency: 3
-max_call_cost_cny: 1.5
+# Minimum per-call reservation. The gateway raises this to the endpoint's
+# prompt/token price ceiling when that is higher, while the daily ¥5 cap remains
+# absolute. ¥1 leaves room for three analysts after a charged failed attempt.
+max_call_cost_cny: 1.0
 baseline_window_days: 90
 evidence_retention_days: 120
 standard_min_chars: 700

--- a/tests/test_budget_staging.py
+++ b/tests/test_budget_staging.py
@@ -129,6 +129,22 @@ def test_persona_budget_can_reserve_three_concurrent_analysts_after_planning() -
     config = load_config(Path("config"))
     assert config.persona is not None
     ledger = BudgetLedger(config.persona.budget)
+    failed_attempt = ModelRun(
+        role="persona_planner",
+        requested_provider="deepseek",
+        requested_model="deepseek-v4-pro",
+        actual_provider="deepseek",
+        actual_model="deepseek-v4-pro",
+        attempt=1,
+        status="failed",
+        latency_ms=1,
+        input_tokens=64_326,
+        output_tokens=61_410,
+        cost_cny=0.585767,
+        error_type="SchemaError",
+    )
+    ledger.record_requests(7, BudgetStage.PERSONA)
+    ledger.record(failed_attempt, BudgetStage.PERSONA)
     planner = ModelRun(
         role="persona_planner",
         requested_provider="deepseek",
@@ -140,7 +156,7 @@ def test_persona_budget_can_reserve_three_concurrent_analysts_after_planning() -
         latency_ms=1,
         input_tokens=12_305,
         output_tokens=23_663,
-        cost_cny=0.19,
+        cost_cny=0.25,
     )
     ledger.record_requests(1, BudgetStage.PERSONA)
     ledger.record(planner, BudgetStage.PERSONA)
@@ -156,7 +172,7 @@ def test_persona_budget_can_reserve_three_concurrent_analysts_after_planning() -
 
     assert ledger.reserved_requests == 6
     assert ledger.reserved_output_tokens == 288_000
-    assert ledger.remaining_cost() == pytest.approx(0.31)
+    assert ledger.remaining_cost() == pytest.approx(1.164233)
 
 
 def test_stage_totals_are_reported_separately(tmp_path: Path) -> None:


### PR DESCRIPTION
## Root cause
The persona ledger correctly retains real spend from failed attempts (¥0.585767 today), but a fixed ¥1.5 minimum reservation for each of three concurrent analysts locked another ¥4.5. That exceeded the ¥5 daily ceiling before any analyst request started, even though the gateway's endpoint/token pricing already computes a lower, prompt-aware ceiling.

## Fix
- reduce only the fixed reservation floor to ¥1.0
- retain the prompt/token-derived reservation ceiling and absolute ¥5 daily cap
- cover a charged prior failure plus a new planner and three concurrent analysts in regression tests

## Verification
- full pytest suite passed
- Ruff passed
- mypy passed for all 36 source files
- diff check passed