### PR TITLE
fix: verify persona analysis before editing

### DIFF
--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -36,7 +36,7 @@ from ai_daily.persona_models import (
 )
 from ai_daily.persona_render import render_persona
 from ai_daily.persona_snapshot import load_upstream_snapshot
-from ai_daily.persona_verifier import VerificationScope, verify_edition
+from ai_daily.persona_verifier import VerificationScope, verify_analysis_item, verify_edition
 from ai_daily.publication import PublicationLevel
 from ai_daily.site_publisher import SiteLayout, publication_lock
 
@@ -138,9 +138,9 @@ class PersonaPipeline:
             run_dir / "baselines.json",
             {key: value.model_dump(mode="json") for key, value in baselines.items()},
         )
-        analyses = await self._analyze(snapshot, plan, memories, baselines)
-        write_artifact(run_dir / "analyses.json", analyses)
         scope = _verification_scope(snapshot, plan, baselines, memories, baseline_map)
+        analyses = await self._analyze(snapshot, plan, memories, baselines, scope)
+        write_artifact(run_dir / "analyses.json", analyses)
         draft = await self._edit(snapshot, plan, analyses, scope)
         write_artifact(run_dir / "draft.json", draft)
         final = await self._review(snapshot, draft, scope, run_dir)
@@ -183,10 +183,17 @@ class PersonaPipeline:
         plan: PersonaPlan,
         memories: dict[str, Any],
         baselines: dict[str, Any],
+        scope: VerificationScope,
     ) -> list[AnalysisItem]:
         selections = [item for item in plan.selections if item.grade in {"S", "A"}]
         tasks = [
-            self._analyze_one(snapshot, selection, memories, baselines.get(selection.event_id))
+            self._analyze_one(
+                snapshot,
+                selection,
+                memories,
+                baselines.get(selection.event_id),
+                scope,
+            )
             for selection in selections
         ]
         return list(await asyncio.gather(*tasks)) if tasks else []
@@ -197,6 +204,7 @@ class PersonaPipeline:
         selection: PlanSelection,
         memories: dict[str, Any],
         baseline: Any,
+        scope: VerificationScope,
     ) -> AnalysisItem:
         event = _analyst_event_row(snapshot, selection)
         selected_memories = [
@@ -220,7 +228,7 @@ class PersonaPipeline:
             AnalystOutput,
             _analyst_instructions(),
             prompt,
-            validator=lambda value: _validate_analysis(value, selection),
+            validator=lambda value: _validate_analysis(value, selection, snapshot, scope),
             stage=BudgetStage.PERSONA,
         )
         return output.item
@@ -232,14 +240,15 @@ class PersonaPipeline:
         analyses: list[AnalysisItem],
         scope: VerificationScope,
     ) -> EditionDraft:
-        prompt = _json_prompt(
+        prompt = _json_prompt_limited(
+            90_000,
             column_id=self.persona.column_id,
             target_date=snapshot.target_date.isoformat(),
             input_marker=snapshot.publication_marker,
             ai_disclosure=self.persona.ai_disclosure,
             plan=plan.model_dump(mode="json"),
             analyses=[item.model_dump(mode="json") for item in analyses],
-            candidates=_event_rows(snapshot, [item.event_id for item in plan.selections]),
+            sources=_edition_source_rows(snapshot, plan),
         )
 
         def validate(value: EditionDraft) -> None:
@@ -427,6 +436,31 @@ def _analyst_event_row(snapshot: Any, selection: PlanSelection) -> dict[str, Any
     }
 
 
+def _edition_source_rows(snapshot: Any, plan: PersonaPlan) -> list[dict[str, Any]]:
+    selected = {selection.event_id: set(selection.evidence_ids) for selection in plan.selections}
+    watchlist = set(plan.watchlist_event_ids)
+    rows: list[dict[str, Any]] = []
+    for bundle in snapshot.evidence_bundles:
+        if bundle.event_id not in selected and bundle.event_id not in watchlist:
+            continue
+        allowed = selected.get(bundle.event_id)
+        evidence = (
+            bundle.evidence
+            if allowed is None
+            else [item for item in bundle.evidence if item.evidence_id in allowed]
+        )
+        for item in evidence[:3]:
+            rows.append(
+                {
+                    "event_id": bundle.event_id,
+                    "evidence_id": item.evidence_id,
+                    "url": str(item.url),
+                    "excerpt": _bounded_text(item.excerpt, 400),
+                }
+            )
+    return rows
+
+
 def _json_prompt(**payload: Any) -> str:
     return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
 
@@ -442,10 +476,7 @@ def _bounded_text(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     prefix = text[:limit]
-    boundary = max(
-        prefix.rfind(mark)
-        for mark in ("。", "\uff01", "\uff1f", ".", "!", "?", "\n")
-    )
+    boundary = max(prefix.rfind(mark) for mark in ("。", "\uff01", "\uff1f", ".", "!", "?", "\n"))
     return prefix[: boundary + 1] if boundary >= limit // 2 else ""
 
 
@@ -476,7 +507,9 @@ def _analyst_instructions() -> str:
 def _edition_instructions(minimum: int, maximum: int) -> str:
     return (
         "你是版面编辑，只可重组输入分析，不得增加外部事实。"
-        "把 items 路径按最终顺序重写；draft.claims 必须完整包含所有公开块使用的 claim，"
+        "输入分析已逐条通过证据校验。可删减或压缩判断，但事实 claim 若保留，"
+        "text 必须原样等于 quote，不得改写事实原文。把 items 路径按最终顺序重写；"
+        "draft.claims 必须完整包含所有公开块使用的 claim，"
         "item.claims 必须恰好包含该 item 的 claims。"
         "每个 block.text 必须严格等于其 claims.text 顺序拼接。"
         "所有推论、建议和不确定性必须保留“判断：”“建议：”“不确定性：”前缀。"
@@ -542,7 +575,12 @@ def _validate_plan(
         raise ValueError("persona plan omitted inventory is incomplete")
 
 
-def _validate_analysis(output: AnalystOutput, selection: PlanSelection) -> None:
+def _validate_analysis(
+    output: AnalystOutput,
+    selection: PlanSelection,
+    snapshot: Any,
+    scope: VerificationScope,
+) -> None:
     item = output.item
     if item.event_id != selection.event_id or item.grade != selection.grade:
         raise ValueError("analyst output does not match selection")
@@ -550,6 +588,7 @@ def _validate_analysis(output: AnalystOutput, selection: PlanSelection) -> None:
         raise ValueError("analyst output added evidence")
     if not set(item.memory_ids) <= set(selection.memory_ids):
         raise ValueError("analyst output added memory")
+    verify_analysis_item(item, snapshot, scope)
 
 
 def _validate_draft_identity(

--- a/src/ai_daily/persona_verifier.py
+++ b/src/ai_daily/persona_verifier.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from ai_daily.content import quote_supports
 from ai_daily.persona_models import (
     AnalysisClaim,
+    AnalysisItem,
     EditionDraft,
     EditorialMemory,
     PersonaEdition,
@@ -80,6 +81,62 @@ def verify_edition(
     payload = draft.model_dump(mode="json")
     edition = PersonaEdition.model_validate({**payload, "payload_sha256": "0" * 64})
     return edition.model_copy(update={"payload_sha256": edition.compute_payload_sha256()})
+
+
+def verify_analysis_item(
+    item: AnalysisItem,
+    snapshot: UpstreamSnapshot,
+    scope: VerificationScope,
+) -> None:
+    """Apply edition evidence rules before an analyst result can be reused."""
+    current_by_event = {
+        bundle.event_id: {evidence.evidence_id: evidence.excerpt for evidence in bundle.evidence}
+        for bundle in snapshot.evidence_bundles
+    }
+    current = current_by_event.get(item.event_id, {})
+    if not item.evidence_ids or not set(item.evidence_ids) <= set(current):
+        raise ValueError(f"item {item.event_id} has out-of-scope current evidence")
+    if len(item.evidence_ids) != len(set(item.evidence_ids)):
+        raise ValueError(f"item {item.event_id} contains duplicate current evidence")
+    if not set(item.memory_ids) <= scope.memory_ids_by_event.get(item.event_id, set()):
+        raise ValueError(f"item {item.event_id} has out-of-scope memory")
+
+    claims = _claim_map(item.claims)
+    blocks = list(_analysis_blocks(item))
+    for path, block in blocks:
+        _verify_block(path, block, claims)
+    _verify_claim_inventory(blocks, claims)
+    for claim in claims.values():
+        if not set(claim.current_evidence_ids) <= set(item.evidence_ids):
+            raise ValueError(f"item {item.event_id} claim used undeclared evidence")
+        if not set(claim.experience_memory_ids) <= set(item.memory_ids):
+            raise ValueError(f"item {item.event_id} claim used undeclared memory")
+        _verify_claim(claim, current, scope, item.event_id)
+
+    confirmed = [claims[claim_id] for claim_id in item.confirmed_change_block.claim_ids]
+    if any(claim.claim_type != "current_fact" for claim in confirmed):
+        raise ValueError(f"item {item.event_id} confirmed change must be current facts")
+    if item.delta_from_before_block is not None:
+        delta = [claims[claim_id] for claim_id in item.delta_from_before_block.claim_ids]
+        if not all(claim.current_evidence_ids and claim.baseline_evidence_ids for claim in delta):
+            raise ValueError(f"item {item.event_id} delta lacks current or baseline evidence")
+
+
+def _analysis_blocks(item: AnalysisItem) -> Iterable[tuple[str, PublicTextBlock]]:
+    names = (
+        "headline_block",
+        "confirmed_change_block",
+        "delta_from_before_block",
+        "importance_block",
+        "product_implication_block",
+        "recommended_action_block",
+        "counter_case_block",
+        "watch_signal_block",
+    )
+    for name in names:
+        block = getattr(item, name)
+        if block is not None:
+            yield f"items[0].{name}", block
 
 
 def _claim_map(claims: list[AnalysisClaim]) -> dict[str, AnalysisClaim]:
@@ -280,13 +337,10 @@ def _verify_item_sources(
         if item.delta_from_before_block is not None:
             delta_claims = [claims[item_id] for item_id in item.delta_from_before_block.claim_ids]
             if not all(
-                claim.current_evidence_ids and claim.baseline_evidence_ids
-                for claim in delta_claims
+                claim.current_evidence_ids and claim.baseline_evidence_ids for claim in delta_claims
             ):
                 raise ValueError(f"item {item.event_id} delta lacks current or baseline evidence")
-        confirmed_claims = [
-            claims[item_id] for item_id in item.confirmed_change_block.claim_ids
-        ]
+        confirmed_claims = [claims[item_id] for item_id in item.confirmed_change_block.claim_ids]
         if any(claim.claim_type != "current_fact" for claim in confirmed_claims):
             raise ValueError(f"item {item.event_id} confirmed change must be current facts")
         item_paths = {path for path, _ in _blocks(draft) if path.startswith(f"items[{index}].")}
@@ -333,11 +387,7 @@ def _verify_length(
     config: PersonaRuntimeConfig,
 ) -> None:
     body_chars = sum(
-        sum(
-            1
-            for character in unicodedata.normalize("NFC", block.text)
-            if not character.isspace()
-        )
+        sum(1 for character in unicodedata.normalize("NFC", block.text) if not character.isspace())
         for path, block in blocks
         if path not in {"title_block", "digest_block"}
     )

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -52,7 +52,7 @@ from ai_daily.persona_snapshot import (
     load_upstream_snapshot,
     persist_upstream_snapshot,
 )
-from ai_daily.persona_verifier import VerificationScope, verify_edition
+from ai_daily.persona_verifier import VerificationScope, verify_analysis_item, verify_edition
 from ai_daily.persona_wechat import (
     PublicationSlots,
     WechatAPIError,
@@ -134,9 +134,7 @@ def _snapshot(layout: SiteLayout) -> UpstreamSnapshot:
 def test_analyst_prompt_drops_nested_raw_items_and_stays_bounded() -> None:
     event = factories.event(0)
     raw = event.items[0].model_copy(update={"summary": "长原文。" * 2_500})
-    event = event.model_copy(
-        update={"summary": "事件摘要。" * 1_500, "items": [raw] * 8}
-    )
+    event = event.model_copy(update={"summary": "事件摘要。" * 1_500, "items": [raw] * 8})
     bundle = evidence_bundle(event)
     evidence = bundle.evidence[0]
     bundle = bundle.model_copy(
@@ -607,6 +605,32 @@ def test_verifier_rejects_paraphrase_disguised_as_verified_fact(tmp_path: Path) 
         verify_edition(bad, snapshot, _scope(), config)
 
 
+def test_analyst_result_is_evidence_verified_before_editing(tmp_path: Path) -> None:
+    layout = SiteLayout(tmp_path)
+    layout.ensure()
+    snapshot = _snapshot(layout)
+    item = _standard_item("event-0", 0)
+
+    verify_analysis_item(item, snapshot, _scope())
+
+    fact = item.claims[1].model_copy(update={"text": "并非证据原文的事实改写。"})
+    bad = item.model_copy(
+        update={
+            "claims": [item.claims[0], fact, *item.claims[2:]],
+            "confirmed_change_block": item.confirmed_change_block.model_copy(
+                update={"text": fact.text}
+            ),
+        }
+    )
+    with pytest.raises(ValueError, match="exact verified quote"):
+        verify_analysis_item(bad, snapshot, _scope())
+
+    wrong_path = item.claims[0].model_copy(update={"field_path": "items[1].headline_block"})
+    bad_path = item.model_copy(update={"claims": [wrong_path, *item.claims[1:]]})
+    with pytest.raises(ValueError, match="field_path mismatch"):
+        verify_analysis_item(bad_path, snapshot, _scope())
+
+
 def test_verifier_rejects_fabricated_fact_labeled_as_inference(tmp_path: Path) -> None:
     config = load_config(Path("config")).persona
     assert config is not None
@@ -731,9 +755,9 @@ def test_same_day_daily_upgrade_is_rejected_after_persona_freeze(tmp_path: Path)
 
     committed = json.loads(layout.publication_path(TARGET).read_text(encoding="utf-8"))
     assert committed["marker"] == original.marker
-    assert edition.payload_sha256 in (
-        layout.current.resolve() / "jiayu" / "index.html"
-    ).read_text(encoding="utf-8")
+    assert edition.payload_sha256 in (layout.current.resolve() / "jiayu" / "index.html").read_text(
+        encoding="utf-8"
+    )
 
 
 @pytest.mark.asyncio
@@ -1074,9 +1098,7 @@ async def test_reconcile_rejects_tampered_edition_before_remote_access(tmp_path:
     inputs["slots"].claim(slot_id, "attempt-unknown")
     inputs["slots"].update(slot_id, "unknown")
     client = _ReconcileWechatClient("remote-media-id")
-    tampered = inputs["edition"].model_copy(
-        update={"payload_sha256": "f" * 64}
-    )
+    tampered = inputs["edition"].model_copy(update={"payload_sha256": "f" * 64})
 
     with pytest.raises(
         WechatPublicationError,
@@ -1775,9 +1797,7 @@ async def test_pipeline_does_not_freeze_stale_edition_if_marker_changes_before_c
         }
     )
     replacement = replacement_unsigned.model_copy(
-        update={
-            "snapshot_sha256": sha256_payload(replacement_unsigned.canonical_payload())
-        }
+        update={"snapshot_sha256": sha256_payload(replacement_unsigned.canonical_payload())}
     )
     write_artifact(layout.upstream_object_path(replacement.publication_marker), replacement)
 


### PR DESCRIPTION
## Production root cause
The editor exhausted its schema retry because all five analyst artifacts contained claims that the final verifier would reject: factual claim text was paraphrased instead of exactly matching its quote, and some analysts emitted non-zero item paths. Analyst validation previously checked only IDs, so invalid evidence structures reached the expensive editor.

## Fix
- run block, claim inventory, quote, provenance, event scope, and field-path verification on every analyst result
- make invalid analyst results retry at the analyst boundary
- replace full nested candidate payloads in the editor prompt with a bounded source map
- explicitly instruct the editor to preserve exact factual quotes
- add regressions for paraphrased facts and wrong item paths

## Verification
- full pytest suite passed
- Ruff passed
- mypy passed for 36 source files
- diff check passed