### PR TITLE
fix: leave persona retry reservation headroom

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -5,7 +5,9 @@ memories_path: config/persona/memories.yaml
 constitution_path: config/persona/source-artifacts/editorial-constitution-v1.md
 candidate_limit: 30
 memory_limit: 16
-analyst_concurrency: 3
+# Two-way concurrency leaves token and cost reservation headroom for a same-day
+# retry while preserving every selected analysis.
+analyst_concurrency: 2
 # Minimum per-call reservation. The gateway raises this to the endpoint's
 # prompt/token price ceiling when that is higher, while the daily ¥5 cap remains
 # absolute. ¥1 leaves room for three analysts after a charged failed attempt.

--- a/tests/test_budget_staging.py
+++ b/tests/test_budget_staging.py
@@ -125,7 +125,7 @@ def test_a_full_issue_fits_inside_each_stage_allowance() -> None:
         )
 
 
-def test_persona_budget_can_reserve_three_concurrent_analysts_after_planning() -> None:
+def test_persona_budget_can_retry_configured_analysts_after_charged_failures() -> None:
     config = load_config(Path("config"))
     assert config.persona is not None
     ledger = BudgetLedger(config.persona.budget)
@@ -138,12 +138,12 @@ def test_persona_budget_can_reserve_three_concurrent_analysts_after_planning() -
         attempt=1,
         status="failed",
         latency_ms=1,
-        input_tokens=64_326,
-        output_tokens=61_410,
-        cost_cny=0.585767,
+        input_tokens=217_846,
+        output_tokens=220_304,
+        cost_cny=2.06096,
         error_type="SchemaError",
     )
-    ledger.record_requests(7, BudgetStage.PERSONA)
+    ledger.record_requests(15, BudgetStage.PERSONA)
     ledger.record(failed_attempt, BudgetStage.PERSONA)
     planner = ModelRun(
         role="persona_planner",
@@ -155,8 +155,8 @@ def test_persona_budget_can_reserve_three_concurrent_analysts_after_planning() -
         status="ok",
         latency_ms=1,
         input_tokens=12_305,
-        output_tokens=23_663,
-        cost_cny=0.25,
+        output_tokens=12_836,
+        cost_cny=0.12,
     )
     ledger.record_requests(1, BudgetStage.PERSONA)
     ledger.record(planner, BudgetStage.PERSONA)
@@ -170,9 +170,9 @@ def test_persona_budget_can_reserve_three_concurrent_analysts_after_planning() -
             output_tokens=96_000,
         )
 
-    assert ledger.reserved_requests == 6
-    assert ledger.reserved_output_tokens == 288_000
-    assert ledger.remaining_cost() == pytest.approx(1.164233)
+    assert ledger.reserved_requests == 4
+    assert ledger.reserved_output_tokens == 192_000
+    assert ledger.remaining_cost() == pytest.approx(0.81904)
 
 
 def test_stage_totals_are_reported_separately(tmp_path: Path) -> None:


### PR DESCRIPTION
## Root cause
After the evidence-verification fix, today's retained ledger has 220,304 output tokens already spent. Three concurrent analysts would reserve another 288k after planning and exceed the 500k daily token ceiling before any request starts.

## Fix
- reduce analyst concurrency from three to two without reducing selected stories or analysis depth
- cover the exact charged production ledger shape, a new planner, and the configured analyst batch in a regression test

## Verification
- full pytest suite passed
- Ruff passed
- mypy passed for 36 source files
- diff check passed