### PR TITLE
fix: preserve persona validation diagnostics

### DIFF
--- a/src/ai_daily/model_gateway.py
+++ b/src/ai_daily/model_gateway.py
@@ -9,7 +9,12 @@ from typing import TypeVar
 import httpx
 from pydantic import BaseModel
 from pydantic_ai import Agent, ModelRetry, ModelSettings
-from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError, UsageLimitExceeded
+from pydantic_ai.exceptions import (
+    ModelAPIError,
+    ModelHTTPError,
+    UnexpectedModelBehavior,
+    UsageLimitExceeded,
+)
 from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.alibaba import AlibabaProvider
 from pydantic_ai.providers.deepseek import DeepSeekProvider
@@ -42,6 +47,10 @@ class MissingProviderSecret(RuntimeError):
 
 
 class ModelInvocationFailed(RuntimeError):
+    pass
+
+
+class ModelOutputValidationFailed(RuntimeError):
     pass
 
 
@@ -167,6 +176,7 @@ class ModelGateway:
                 output_tokens=reserved_output,
             )
         usage = RunUsage()
+        validation_errors: list[str] = []
         try:
             agent: Agent[None, OutputT] = Agent(
                 self._build_model(invocation.endpoint),
@@ -175,7 +185,7 @@ class ModelGateway:
                 retries=OUTPUT_RETRIES,
             )
             if validator is not None:
-                agent.output_validator(self._semantic_validator(validator))
+                agent.output_validator(self._semantic_validator(validator, validation_errors))
             async with agent:
                 result = await agent.run(
                     prompt,
@@ -191,7 +201,12 @@ class ModelGateway:
             self._record_failed_run(invocation, started, error, usage, stage, reservation)
             raise
         except Exception as error:
-            self._record_failed_run(invocation, started, error, usage, stage, reservation)
+            recorded_error: Exception = error
+            if isinstance(error, UnexpectedModelBehavior) and validation_errors:
+                recorded_error = ModelOutputValidationFailed(validation_errors[-1])
+            self._record_failed_run(invocation, started, recorded_error, usage, stage, reservation)
+            if recorded_error is not error:
+                raise recorded_error from error
             raise
         run = self._success_run(
             invocation,
@@ -281,12 +296,15 @@ class ModelGateway:
     @staticmethod
     def _semantic_validator(
         validator: Callable[[OutputT], None],
+        errors: list[str],
     ) -> Callable[[OutputT], OutputT]:
         def validate(output: OutputT) -> OutputT:
             try:
                 validator(output)
             except ValueError as error:
-                raise ModelRetry(str(error)) from error
+                message = str(error).replace("\n", " ").strip()[:300]
+                errors.append(message)
+                raise ModelRetry(message) from error
             return output
 
         return validate

--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -187,16 +187,26 @@ class PersonaPipeline:
     ) -> list[AnalysisItem]:
         selections = [item for item in plan.selections if item.grade in {"S", "A"}]
         tasks = [
-            self._analyze_one(
-                snapshot,
-                selection,
-                memories,
-                baselines.get(selection.event_id),
-                scope,
+            asyncio.create_task(
+                self._analyze_one(
+                    snapshot,
+                    selection,
+                    memories,
+                    baselines.get(selection.event_id),
+                    scope,
+                )
             )
             for selection in selections
         ]
-        return list(await asyncio.gather(*tasks)) if tasks else []
+        if not tasks:
+            return []
+        try:
+            return list(await asyncio.gather(*tasks))
+        except BaseException:
+            for task in tasks:
+                task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+            raise
 
     async def _analyze_one(
         self,

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -320,7 +320,7 @@ async def test_semantic_validation_failure_does_not_cross_provider(
 
     monkeypatch.setattr(gateway, "_build_model", build_model)
 
-    with pytest.raises(ModelInvocationFailed, match="UnexpectedModelBehavior"):
+    with pytest.raises(ModelInvocationFailed, match="event_id must be event-1"):
         await gateway.generate(
             "judge",
             JudgeDecision,
@@ -334,6 +334,7 @@ async def test_semantic_validation_failure_does_not_cross_provider(
     assert gateway.ledger.requests == 2
     assert gateway.runs[-1].request_count == 2
     assert gateway.runs[-1].status == "failed"
+    assert gateway.runs[-1].error_type == "ModelOutputValidationFailed"
     assert gateway.runs[-1].input_tokens > 0
     assert gateway.ledger.reserved_requests == 0
     assert gateway.ledger.reserved_cost_cny == pytest.approx(0)


### PR DESCRIPTION
## Root cause
Pydantic AI replaces the final semantic validator error with a generic retry-exhausted exception. Production therefore could not distinguish a bad quote, field path, claim inventory, or scope violation. Concurrent sibling analyst tasks were also not explicitly cancelled and awaited after the first failure.

## Fix
- preserve the last controlled validator error in a safe 300-character diagnostic
- record failed model runs as ModelOutputValidationFailed
- cancel and await sibling analyst tasks before propagating a failure
- keep provider errors sanitized as before

## Verification
- full pytest suite passed
- Ruff passed
- mypy passed for 36 source files
- diff check passed