### PR TITLE
fix: canonicalize persona facts before verification

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -21,10 +21,12 @@ no_major_max_chars: 600
 publish_mode: draft_only
 ai_disclosure: 本文由 AI 参与资料整理和初稿生成，并经过证据约束与自动审稿。
 budget:
-  request_limit: 40
-  input_token_limit: 500000
+  # These are runaway backstops, not normal-run quotas. The ¥5 ceiling remains
+  # binding before current DeepSeek pricing can consume these token allowances.
+  request_limit: 60
+  input_token_limit: 1000000
   # The persona gateway reserves the worst case before a call. Three concurrent
   # 48k-output calls with one schema retry can reserve 288k even though actual
   # usage is much lower. Keep tokens non-binding and let the ¥5 ceiling stop spend.
-  output_token_limit: 500000
+  output_token_limit: 800000
   cost_cny_limit: 5.0

--- a/src/ai_daily/model_gateway.py
+++ b/src/ai_daily/model_gateway.py
@@ -91,7 +91,7 @@ class ModelGateway:
         output_type: type[OutputT],
         instructions: str,
         prompt: str,
-        validator: Callable[[OutputT], None] | None = None,
+        validator: Callable[[OutputT], OutputT | None] | None = None,
         stage: BudgetStage = BudgetStage.JUDGE,
     ) -> OutputT:
         role_config = self.config.roles[role]
@@ -122,7 +122,7 @@ class ModelGateway:
         output_type: type[OutputT],
         instructions: str,
         prompt: str,
-        validator: Callable[[OutputT], None] | None,
+        validator: Callable[[OutputT], OutputT | None] | None,
         stage: BudgetStage,
     ) -> OutputT:
         async with self._concurrency:
@@ -141,7 +141,7 @@ class ModelGateway:
         output_type: type[OutputT],
         instructions: str,
         prompt: str,
-        validator: Callable[[OutputT], None] | None,
+        validator: Callable[[OutputT], OutputT | None] | None,
         stage: BudgetStage,
     ) -> OutputT:
         started = self.clock()
@@ -295,17 +295,17 @@ class ModelGateway:
 
     @staticmethod
     def _semantic_validator(
-        validator: Callable[[OutputT], None],
+        validator: Callable[[OutputT], OutputT | None],
         errors: list[str],
     ) -> Callable[[OutputT], OutputT]:
         def validate(output: OutputT) -> OutputT:
             try:
-                validator(output)
+                normalized = validator(output)
             except ValueError as error:
                 message = str(error).replace("\n", " ").strip()[:300]
                 errors.append(message)
                 raise ModelRetry(message) from error
-            return output
+            return normalized if normalized is not None else output
 
         return validate
 

--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -36,7 +36,12 @@ from ai_daily.persona_models import (
 )
 from ai_daily.persona_render import render_persona
 from ai_daily.persona_snapshot import load_upstream_snapshot
-from ai_daily.persona_verifier import VerificationScope, verify_analysis_item, verify_edition
+from ai_daily.persona_verifier import (
+    VerificationScope,
+    normalize_analysis_item,
+    verify_analysis_item,
+    verify_edition,
+)
 from ai_daily.publication import PublicationLevel
 from ai_daily.site_publisher import SiteLayout, publication_lock
 
@@ -590,8 +595,8 @@ def _validate_analysis(
     selection: PlanSelection,
     snapshot: Any,
     scope: VerificationScope,
-) -> None:
-    item = output.item
+) -> AnalystOutput:
+    item = normalize_analysis_item(output.item)
     if item.event_id != selection.event_id or item.grade != selection.grade:
         raise ValueError("analyst output does not match selection")
     if not set(item.evidence_ids) <= set(selection.evidence_ids):
@@ -599,6 +604,7 @@ def _validate_analysis(
     if not set(item.memory_ids) <= set(selection.memory_ids):
         raise ValueError("analyst output added memory")
     verify_analysis_item(item, snapshot, scope)
+    return output.model_copy(update={"item": item})
 
 
 def _validate_draft_identity(

--- a/src/ai_daily/persona_verifier.py
+++ b/src/ai_daily/persona_verifier.py
@@ -27,6 +27,16 @@ INTERPRETIVE_PREFIX = {
     "uncertainty": "不确定性：",
 }
 ANCHOR_RE = re.compile(r"(?<![A-Za-z0-9])(?:[A-Za-z][A-Za-z0-9._-]{2,}|\d[\d.]*%?)")
+ANALYSIS_BLOCK_NAMES = (
+    "headline_block",
+    "confirmed_change_block",
+    "delta_from_before_block",
+    "importance_block",
+    "product_implication_block",
+    "recommended_action_block",
+    "counter_case_block",
+    "watch_signal_block",
+)
 
 
 @dataclass(frozen=True)
@@ -122,18 +132,37 @@ def verify_analysis_item(
             raise ValueError(f"item {item.event_id} delta lacks current or baseline evidence")
 
 
+def normalize_analysis_item(item: AnalysisItem) -> AnalysisItem:
+    """Canonicalize evidence-bound structure without rewriting model judgments."""
+    path_by_claim: dict[str, str] = {}
+    for path, block in _analysis_blocks(item):
+        for claim_id in block.claim_ids:
+            previous = path_by_claim.setdefault(claim_id, path)
+            if previous != path:
+                raise ValueError(f"claim {claim_id} is reused across public blocks")
+
+    claims: list[AnalysisClaim] = []
+    for claim in item.claims:
+        claim_updates: dict[str, str] = {}
+        if claim.claim_id in path_by_claim:
+            claim_updates["field_path"] = path_by_claim[claim.claim_id]
+        if claim.claim_type in {"current_fact", "baseline_fact", "experience_fact"}:
+            claim_updates["text"] = "；".join(quote.quote for quote in claim.quotes)
+        claims.append(claim.model_copy(update=claim_updates))
+
+    claims_by_id = {claim.claim_id: claim for claim in claims}
+    item_updates: dict[str, object] = {"claims": claims}
+    for name in ANALYSIS_BLOCK_NAMES:
+        block = getattr(item, name)
+        if block is None:
+            continue
+        text = "".join(claims_by_id[claim_id].text for claim_id in block.claim_ids)
+        item_updates[name] = block.model_copy(update={"text": text})
+    return item.model_copy(update=item_updates)
+
+
 def _analysis_blocks(item: AnalysisItem) -> Iterable[tuple[str, PublicTextBlock]]:
-    names = (
-        "headline_block",
-        "confirmed_change_block",
-        "delta_from_before_block",
-        "importance_block",
-        "product_implication_block",
-        "recommended_action_block",
-        "counter_case_block",
-        "watch_signal_block",
-    )
-    for name in names:
+    for name in ANALYSIS_BLOCK_NAMES:
         block = getattr(item, name)
         if block is not None:
             yield f"items[0].{name}", block

--- a/tests/test_budget_staging.py
+++ b/tests/test_budget_staging.py
@@ -138,12 +138,12 @@ def test_persona_budget_can_retry_configured_analysts_after_charged_failures() -
         attempt=1,
         status="failed",
         latency_ms=1,
-        input_tokens=217_846,
-        output_tokens=220_304,
-        cost_cny=2.06096,
+        input_tokens=286_577,
+        output_tokens=288_723,
+        cost_cny=2.70439,
         error_type="SchemaError",
     )
-    ledger.record_requests(15, BudgetStage.PERSONA)
+    ledger.record_requests(26, BudgetStage.PERSONA)
     ledger.record(failed_attempt, BudgetStage.PERSONA)
     planner = ModelRun(
         role="persona_planner",
@@ -155,8 +155,8 @@ def test_persona_budget_can_retry_configured_analysts_after_charged_failures() -
         status="ok",
         latency_ms=1,
         input_tokens=12_305,
-        output_tokens=12_836,
-        cost_cny=0.12,
+        output_tokens=8_507,
+        cost_cny=0.09,
     )
     ledger.record_requests(1, BudgetStage.PERSONA)
     ledger.record(planner, BudgetStage.PERSONA)
@@ -172,7 +172,7 @@ def test_persona_budget_can_retry_configured_analysts_after_charged_failures() -
 
     assert ledger.reserved_requests == 4
     assert ledger.reserved_output_tokens == 192_000
-    assert ledger.remaining_cost() == pytest.approx(0.81904)
+    assert ledger.remaining_cost() == pytest.approx(0.20561)
 
 
 def test_stage_totals_are_reported_separately(tmp_path: Path) -> None:

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -52,7 +52,12 @@ from ai_daily.persona_snapshot import (
     load_upstream_snapshot,
     persist_upstream_snapshot,
 )
-from ai_daily.persona_verifier import VerificationScope, verify_analysis_item, verify_edition
+from ai_daily.persona_verifier import (
+    VerificationScope,
+    normalize_analysis_item,
+    verify_analysis_item,
+    verify_edition,
+)
 from ai_daily.persona_wechat import (
     PublicationSlots,
     WechatAPIError,
@@ -629,6 +634,13 @@ def test_analyst_result_is_evidence_verified_before_editing(tmp_path: Path) -> N
     bad_path = item.model_copy(update={"claims": [wrong_path, *item.claims[1:]]})
     with pytest.raises(ValueError, match="field_path mismatch"):
         verify_analysis_item(bad_path, snapshot, _scope())
+
+    normalized = normalize_analysis_item(
+        bad_path.model_copy(update={"claims": [wrong_path, *bad.claims[1:]]})
+    )
+    verify_analysis_item(normalized, snapshot, _scope())
+    assert normalized.claims[1].text == normalized.claims[1].quotes[0].quote
+    assert normalized.claims[0].field_path == "items[0].headline_block"
 
 
 def test_verifier_rejects_fabricated_fact_labeled_as_inference(tmp_path: Path) -> None:


### PR DESCRIPTION
## Production root cause
The model supplied evidence quotes but repeatedly paraphrased factual public text even after a retry explicitly told it to use the exact quote. This is deterministic structure work, not editorial judgment, and retrying the model is both less reliable and more expensive.

## Fix
- canonicalize factual claim text to the exact joined quote before verification
- rebase analyst claim field paths from actual block membership
- keep all source, quote-support, inference-anchor, scope, and inventory verification unchanged
- allow validators to return a normalized typed result
- raise persona request/token runaway backstops so the unchanged ¥5 cost cap remains the binding control after charged retries

## Verification
- full pytest suite passed
- Ruff passed
- mypy passed for 36 source files
- regressions prove raw invalid facts/paths are rejected and canonicalized results pass evidence verification