### PR TITLE
fix: settle persona analyst batches

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -9,7 +9,7 @@ memory_limit: 16
 # retry while preserving every selected analysis.
 analyst_concurrency: 2
 # Minimum per-call reservation. The gateway raises this to the prompt/token
-# price ceiling (about ¥0.6-1.0 for current calls), while the ¥5 cap is absolute.
+# price ceiling (about ¥0.6-1.0 for current calls), while the ¥8 cap is absolute.
 max_call_cost_cny: 0.25
 baseline_window_days: 90
 evidence_retention_days: 120
@@ -20,12 +20,14 @@ no_major_max_chars: 600
 publish_mode: draft_only
 ai_disclosure: 本文由 AI 参与资料整理和初稿生成，并经过证据约束与自动审稿。
 budget:
-  # These are runaway backstops, not normal-run quotas. The ¥5 ceiling remains
+  # These are runaway backstops, not normal-run quotas. The ¥8 ceiling remains
   # binding before current DeepSeek pricing can consume these token allowances.
   request_limit: 60
   input_token_limit: 1000000
   # The persona gateway reserves the worst case before a call. Three concurrent
   # 48k-output calls with one schema retry can reserve 288k even though actual
-  # usage is much lower. Keep tokens non-binding and let the ¥5 ceiling stop spend.
+  # usage is much lower. Keep tokens non-binding and let the ¥8 ceiling stop spend.
   output_token_limit: 800000
-  cost_cny_limit: 5.0
+  # Fresh successful editions are expected to stay around ¥1-2. The higher hard
+  # stop preserves same-day recovery after charged provider or validation failures.
+  cost_cny_limit: 8.0

--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -191,6 +191,20 @@ class PersonaPipeline:
         scope: VerificationScope,
     ) -> list[AnalysisItem]:
         selections = [item for item in plan.selections if item.grade in {"S", "A"}]
+        analyses: list[AnalysisItem] = []
+        for offset in range(0, len(selections), self.persona.analyst_concurrency):
+            batch = selections[offset : offset + self.persona.analyst_concurrency]
+            analyses.extend(await self._analyze_batch(snapshot, batch, memories, baselines, scope))
+        return analyses
+
+    async def _analyze_batch(
+        self,
+        snapshot: Any,
+        selections: list[PlanSelection],
+        memories: dict[str, Any],
+        baselines: dict[str, Any],
+        scope: VerificationScope,
+    ) -> list[AnalysisItem]:
         tasks = [
             asyncio.create_task(
                 self._analyze_one(
@@ -203,8 +217,6 @@ class PersonaPipeline:
             )
             for selection in selections
         ]
-        if not tasks:
-            return []
         try:
             return list(await asyncio.gather(*tasks))
         except BaseException:

--- a/tests/test_budget_staging.py
+++ b/tests/test_budget_staging.py
@@ -138,12 +138,12 @@ def test_persona_budget_can_retry_configured_analysts_after_charged_failures() -
         attempt=1,
         status="failed",
         latency_ms=1,
-        input_tokens=340_861,
-        output_tokens=331_919,
-        cost_cny=3.144705,
+        input_tokens=415_756,
+        output_tokens=418_544,
+        cost_cny=3.921398,
         error_type="SchemaError",
     )
-    ledger.record_requests(31, BudgetStage.PERSONA)
+    ledger.record_requests(39, BudgetStage.PERSONA)
     ledger.record(failed_attempt, BudgetStage.PERSONA)
     planner = ModelRun(
         role="persona_planner",
@@ -172,7 +172,7 @@ def test_persona_budget_can_retry_configured_analysts_after_charged_failures() -
 
     assert ledger.reserved_requests == 4
     assert ledger.reserved_output_tokens == 192_000
-    assert ledger.remaining_cost() == pytest.approx(0.365295)
+    assert ledger.remaining_cost() == pytest.approx(2.588602)
 
 
 def test_stage_totals_are_reported_separately(tmp_path: Path) -> None:

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -198,6 +198,62 @@ def test_analyst_prompt_drops_nested_raw_items_and_stays_bounded() -> None:
     assert len(prompt) <= 10_000
 
 
+@pytest.mark.asyncio
+async def test_analysts_run_in_settled_batches(monkeypatch: pytest.MonkeyPatch) -> None:
+    pipeline = object.__new__(PersonaPipeline)
+    cast(Any, pipeline).persona = SimpleNamespace(analyst_concurrency=2)
+    selections = [
+        PlanSelection(
+            event_id=f"event-{index}",
+            grade="S" if index == 0 else "A",
+            importance_reason="important",
+            evidence_ids=[f"event-{index}-1"],
+        )
+        for index in range(5)
+    ]
+    plan = PersonaPlan(
+        edition_type="standard",
+        today_thesis="important changes",
+        selections=selections,
+        watchlist_event_ids=[],
+        omitted=[],
+    )
+    entered = {selection.event_id: asyncio.Event() for selection in selections}
+    releases = {selection.event_id: asyncio.Event() for selection in selections}
+
+    async def analyze_one(
+        snapshot: object,
+        selection: PlanSelection,
+        memories: dict[str, Any],
+        baseline: object,
+        scope: VerificationScope,
+    ) -> AnalysisItem:
+        entered[selection.event_id].set()
+        await releases[selection.event_id].wait()
+        return _standard_item(selection.event_id, 0)
+
+    monkeypatch.setattr(pipeline, "_analyze_one", analyze_one)
+    running = asyncio.create_task(
+        pipeline._analyze(None, plan, {}, {}, cast(VerificationScope, None))
+    )
+
+    await asyncio.gather(entered["event-0"].wait(), entered["event-1"].wait())
+    releases["event-0"].set()
+    await asyncio.sleep(0)
+    assert not entered["event-2"].is_set()
+    releases["event-1"].set()
+    await asyncio.gather(entered["event-2"].wait(), entered["event-3"].wait())
+    releases["event-2"].set()
+    await asyncio.sleep(0)
+    assert not entered["event-4"].is_set()
+    releases["event-3"].set()
+    await entered["event-4"].wait()
+    releases["event-4"].set()
+
+    results = await running
+    assert [item.event_id for item in results] == [selection.event_id for selection in selections]
+
+
 def _claim(claim_id: str, path: str, text: str) -> AnalysisClaim:
     return AnalysisClaim(
         claim_id=claim_id,


### PR DESCRIPTION
## Production root cause
Analyst concurrency used a sliding semaphore: as soon as one analyst settled, the next queued analyst tried to reserve while its sibling was still in flight. Near the daily ceiling this caused a valid later analyst to fail even though the whole batch's actual spend would fit after settlement.

## Fix
- execute selected analysts in true settled batches of 2, 2, 1
- cancel and await only siblings in the failing batch
- raise the persona recovery hard stop from ¥5 to ¥8 while retaining the same persistent ledger; fresh successful editions remain expected around ¥1-2
- update the charged-ledger regression and add an async batch-barrier regression

## Verification
- full pytest suite passed
- Ruff passed
- mypy passed for 36 source files
- diff check passed