### PR TITLE
fix: remove unsupported precision from persona claims

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -22,12 +22,12 @@ ai_disclosure: 本文由 AI 参与资料整理和初稿生成，并经过证据�
 budget:
   # These are runaway backstops, not normal-run quotas. The ¥8 ceiling remains
   # binding before current DeepSeek pricing can consume these token allowances.
-  request_limit: 60
-  input_token_limit: 1000000
+  request_limit: 100
+  input_token_limit: 1500000
   # The persona gateway reserves the worst case before a call. Three concurrent
   # 48k-output calls with one schema retry can reserve 288k even though actual
   # usage is much lower. Keep tokens non-binding and let the ¥8 ceiling stop spend.
-  output_token_limit: 800000
+  output_token_limit: 1200000
   # Fresh successful editions are expected to stay around ¥1-2. The higher hard
   # stop preserves same-day recovery after charged provider or validation failures.
   cost_cny_limit: 8.0

--- a/src/ai_daily/persona_verifier.py
+++ b/src/ai_daily/persona_verifier.py
@@ -172,6 +172,11 @@ def normalize_analysis_item(
             {key: value.source_excerpt for key, value in scope.memories.items()},
         ),
     }
+    source_maps = {
+        "current_evidence": current,
+        "baseline_evidence": scope.baseline_evidence,
+        "experience_memory": {key: value.source_excerpt for key, value in scope.memories.items()},
+    }
     for claim in item.claims:
         claim_updates: dict[str, str] = {}
         if claim.claim_id in path_by_claim:
@@ -195,6 +200,13 @@ def normalize_analysis_item(
             ]
             quote_updates = {"quotes": quotes}
             claim_updates["text"] = "；".join(quote.quote for quote in quotes)
+        elif (prefix := INTERPRETIVE_PREFIX.get(claim.claim_type)) is not None:
+            evidence = _claim_evidence_text(claim, source_maps)
+            text = claim.text
+            for token in sorted(_ungrounded_anchors(text, prefix, evidence), key=len, reverse=True):
+                replacement = "相关指标" if token[0].isdigit() else "相关版本"
+                text = text.replace(token, replacement)
+            claim_updates["text"] = text
         claims.append(claim.model_copy(update={**claim_updates, **quote_updates}))
 
     claims_by_id = {claim.claim_id: claim for claim in claims}
@@ -336,21 +348,37 @@ def _verify_interpretive_text(
         return
     if not claim.text.startswith(prefix):
         raise ValueError(f"claim {claim.claim_id} {claim.claim_type} must start with {prefix}")
-    evidence = " ".join(
+    evidence = _claim_evidence_text(claim, source_maps)
+    ungrounded = _ungrounded_anchors(claim.text, prefix, evidence)
+    if ungrounded:
+        raise ValueError(
+            f"claim {claim.claim_id} contains ungrounded entity/version/number anchors"
+        )
+
+
+def _claim_evidence_text(
+    claim: AnalysisClaim,
+    source_maps: dict[str, dict[str, str]],
+) -> str:
+    declared = {
+        "current_evidence": claim.current_evidence_ids,
+        "baseline_evidence": claim.baseline_evidence_ids,
+        "experience_memory": claim.experience_memory_ids,
+    }
+    return " ".join(
         source_maps[kind][source_id]
         for kind, source_ids in declared.items()
         for source_id in source_ids
         if source_id in source_maps[kind]
     ).lower()
-    ungrounded = {
+
+
+def _ungrounded_anchors(text: str, prefix: str, evidence: str) -> set[str]:
+    return {
         token
-        for token in ANCHOR_RE.findall(claim.text.removeprefix(prefix))
+        for token in ANCHOR_RE.findall(text.removeprefix(prefix))
         if token.lower() not in evidence
     }
-    if ungrounded:
-        raise ValueError(
-            f"claim {claim.claim_id} contains ungrounded entity/version/number anchors"
-        )
 
 
 def _allowed_for_event(values: dict[str, set[str]], event_id: str | None) -> set[str]:

--- a/tests/test_budget_staging.py
+++ b/tests/test_budget_staging.py
@@ -138,12 +138,12 @@ def test_persona_budget_can_retry_configured_analysts_after_charged_failures() -
         attempt=1,
         status="failed",
         latency_ms=1,
-        input_tokens=415_756,
-        output_tokens=418_544,
-        cost_cny=3.921398,
+        input_tokens=533_324,
+        output_tokens=674_073,
+        cost_cny=5.888997,
         error_type="SchemaError",
     )
-    ledger.record_requests(39, BudgetStage.PERSONA)
+    ledger.record_requests(50, BudgetStage.PERSONA)
     ledger.record(failed_attempt, BudgetStage.PERSONA)
     planner = ModelRun(
         role="persona_planner",
@@ -172,7 +172,7 @@ def test_persona_budget_can_retry_configured_analysts_after_charged_failures() -
 
     assert ledger.reserved_requests == 4
     assert ledger.reserved_output_tokens == 192_000
-    assert ledger.remaining_cost() == pytest.approx(2.588602)
+    assert ledger.remaining_cost() == pytest.approx(0.621003)
 
 
 def test_stage_totals_are_reported_separately(tmp_path: Path) -> None:

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -686,7 +686,12 @@ def test_analyst_result_is_evidence_verified_before_editing(tmp_path: Path) -> N
     with pytest.raises(ValueError, match="exact verified quote"):
         verify_analysis_item(bad, snapshot, _scope())
 
-    wrong_path = item.claims[0].model_copy(update={"field_path": "items[1].headline_block"})
+    wrong_path = item.claims[0].model_copy(
+        update={
+            "field_path": "items[1].headline_block",
+            "text": "判断：GPT-6 将成本降低 90%。",
+        }
+    )
     bad_path = item.model_copy(update={"claims": [wrong_path, *item.claims[1:]]})
     with pytest.raises(ValueError, match="field_path mismatch"):
         verify_analysis_item(bad_path, snapshot, _scope())
@@ -706,6 +711,8 @@ def test_analyst_result_is_evidence_verified_before_editing(tmp_path: Path) -> N
     assert normalized.claims[1].text == normalized.claims[1].quotes[0].quote
     assert normalized.claims[1].quotes[0].quote == QUOTE
     assert normalized.claims[0].field_path == "items[0].headline_block"
+    assert "GPT-6" not in normalized.claims[0].text
+    assert "90%" not in normalized.claims[0].text
 
 
 def test_verifier_rejects_fabricated_fact_labeled_as_inference(tmp_path: Path) -> None:


### PR DESCRIPTION
## Production root cause
An analyst repeatedly included a version/number token that was not present in its declared evidence. Retrying did not reliably remove the false precision.

## Fix
- deterministically replace unsupported numeric anchors with ‘相关指标’ and unsupported version anchors with ‘相关版本’ during analyst normalization
- keep the direct verifier strict: unnormalized fabricated GPT-6 / 90% claims are still rejected
- raise request/token runaway backstops so the unchanged ¥8 cost ceiling remains binding during same-day recovery
- cover the exact recovered ledger and sanitized-claim behavior in tests

## Verification
- full pytest suite passed
- Ruff passed
- mypy passed for 36 source files
- diff check passed