### PR TITLE
fix: discard persona interpretive quotes

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -9,7 +9,7 @@ memory_limit: 16
 # retry while preserving every selected analysis.
 analyst_concurrency: 2
 # Minimum per-call reservation. The gateway raises this to the prompt/token
-# price ceiling (about ¥0.6-1.0 for current calls), while the ¥8 cap is absolute.
+# price ceiling (about ¥0.6-1.0 for current calls), while the ¥10 cap is absolute.
 max_call_cost_cny: 0.25
 baseline_window_days: 90
 evidence_retention_days: 120
@@ -20,14 +20,14 @@ no_major_max_chars: 600
 publish_mode: draft_only
 ai_disclosure: 本文由 AI 参与资料整理和初稿生成，并经过证据约束与自动审稿。
 budget:
-  # These are runaway backstops, not normal-run quotas. The ¥8 ceiling remains
+  # These are runaway backstops, not normal-run quotas. The ¥10 ceiling remains
   # binding before current DeepSeek pricing can consume these token allowances.
   request_limit: 100
   input_token_limit: 1500000
   # The persona gateway reserves the worst case before a call. Three concurrent
   # 48k-output calls with one schema retry can reserve 288k even though actual
-  # usage is much lower. Keep tokens non-binding and let the ¥8 ceiling stop spend.
+  # usage is much lower. Keep tokens non-binding and let the ¥10 ceiling stop spend.
   output_token_limit: 1200000
   # Fresh successful editions are expected to stay around ¥1-2. The higher hard
   # stop preserves same-day recovery after charged provider or validation failures.
-  cost_cny_limit: 8.0
+  cost_cny_limit: 10.0

--- a/src/ai_daily/persona_verifier.py
+++ b/src/ai_daily/persona_verifier.py
@@ -201,6 +201,7 @@ def normalize_analysis_item(
             quote_updates = {"quotes": quotes}
             claim_updates["text"] = "；".join(quote.quote for quote in quotes)
         elif (prefix := INTERPRETIVE_PREFIX.get(claim.claim_type)) is not None:
+            quote_updates = {"quotes": []}
             evidence = _claim_evidence_text(claim, source_maps)
             text = claim.text
             for token in sorted(_ungrounded_anchors(text, prefix, evidence), key=len, reverse=True):

--- a/tests/test_budget_staging.py
+++ b/tests/test_budget_staging.py
@@ -138,12 +138,12 @@ def test_persona_budget_can_retry_configured_analysts_after_charged_failures() -
         attempt=1,
         status="failed",
         latency_ms=1,
-        input_tokens=533_324,
-        output_tokens=674_073,
-        cost_cny=5.888997,
+        input_tokens=610_253,
+        output_tokens=756_461,
+        cost_cny=6.645534,
         error_type="SchemaError",
     )
-    ledger.record_requests(50, BudgetStage.PERSONA)
+    ledger.record_requests(58, BudgetStage.PERSONA)
     ledger.record(failed_attempt, BudgetStage.PERSONA)
     planner = ModelRun(
         role="persona_planner",
@@ -172,7 +172,7 @@ def test_persona_budget_can_retry_configured_analysts_after_charged_failures() -
 
     assert ledger.reserved_requests == 4
     assert ledger.reserved_output_tokens == 192_000
-    assert ledger.remaining_cost() == pytest.approx(0.621003)
+    assert ledger.remaining_cost() == pytest.approx(1.864466)
 
 
 def test_stage_totals_are_reported_separately(tmp_path: Path) -> None:

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -690,6 +690,13 @@ def test_analyst_result_is_evidence_verified_before_editing(tmp_path: Path) -> N
         update={
             "field_path": "items[1].headline_block",
             "text": "判断：GPT-6 将成本降低 90%。",
+            "quotes": [
+                ClaimQuote(
+                    source_kind="current_evidence",
+                    source_id="event-0-1",
+                    quote="This unsupported quote should be discarded.",
+                )
+            ],
         }
     )
     bad_path = item.model_copy(update={"claims": [wrong_path, *item.claims[1:]]})
@@ -713,6 +720,7 @@ def test_analyst_result_is_evidence_verified_before_editing(tmp_path: Path) -> N
     assert normalized.claims[0].field_path == "items[0].headline_block"
     assert "GPT-6" not in normalized.claims[0].text
     assert "90%" not in normalized.claims[0].text
+    assert normalized.claims[0].quotes == []
 
 
 def test_verifier_rejects_fabricated_fact_labeled_as_inference(tmp_path: Path) -> None:


### PR DESCRIPTION
## Production root cause
A recommendation claim carried a model-generated quote that was not present in its cited evidence. Interpretive claims do not require quotes; they are grounded by their declared evidence IDs, while only factual claims need verbatim quotes.

## Fix
- clear quotes from inference, recommendation, and uncertainty claims during deterministic normalization
- keep source-derived quotes for factual claims
- set the persona recovery hard stop to ¥10; all prior spend remains in the persistent ledger and fresh successful runs are still expected around ¥1-2
- update charged-ledger and normalization regressions

## Verification
- full pytest suite passed
- Ruff passed
- mypy passed for 36 source files
- diff check passed