### PR TITLE
fix: canonicalize persona claim ids

### DIFF
--- a/src/ai_daily/persona_verifier.py
+++ b/src/ai_daily/persona_verifier.py
@@ -17,6 +17,7 @@ from ai_daily.persona_models import (
     PersonaRuntimeConfig,
     PublicTextBlock,
     UpstreamSnapshot,
+    sha256_payload,
 )
 
 FIRST_PERSON_RE = re.compile(r"(?:^|[^你他她它])(?:我|我的|我们|咱们|本人)")
@@ -144,12 +145,37 @@ def normalize_analysis_item(
     scope: VerificationScope,
 ) -> AnalysisItem:
     """Canonicalize evidence-bound structure without rewriting model judgments."""
-    path_by_claim: dict[str, str] = {}
-    for path, block in _analysis_blocks(item):
-        for claim_id in block.claim_ids:
-            previous = path_by_claim.setdefault(claim_id, path)
-            if previous != path:
-                raise ValueError(f"claim {claim_id} is reused across public blocks")
+    claim_templates = _claim_map(item.claims)
+    claims_to_normalize: list[AnalysisClaim] = []
+    block_updates: dict[str, PublicTextBlock] = {}
+    for name in ANALYSIS_BLOCK_NAMES:
+        block = getattr(item, name)
+        if block is None:
+            continue
+        path = f"items[0].{name}"
+        canonical_ids: list[str] = []
+        for position, claim_id in enumerate(block.claim_ids):
+            try:
+                template = claim_templates[claim_id]
+            except KeyError as error:
+                raise ValueError(f"unknown claim id at {path}: {claim_id}") from error
+            canonical_id = "claim-" + sha256_payload(
+                {
+                    "event_id": item.event_id,
+                    "field_path": path,
+                    "position": position,
+                    "source_claim_id": claim_id,
+                }
+            )[:20]
+            canonical_ids.append(canonical_id)
+            claims_to_normalize.append(
+                template.model_copy(
+                    update={"claim_id": canonical_id, "field_path": path}
+                )
+            )
+        block_updates[name] = block.model_copy(update={"claim_ids": canonical_ids})
+    if len(claims_to_normalize) > 12:
+        raise ValueError(f"item {item.event_id} contains more than 12 public claims")
 
     claims: list[AnalysisClaim] = []
     current = {
@@ -172,10 +198,8 @@ def normalize_analysis_item(
             {key: value.source_excerpt for key, value in scope.memories.items()},
         ),
     }
-    for claim in item.claims:
+    for claim in claims_to_normalize:
         claim_updates: dict[str, str] = {}
-        if claim.claim_id in path_by_claim:
-            claim_updates["field_path"] = path_by_claim[claim.claim_id]
         quote_updates: dict[str, object] = {}
         if claim.claim_type in sources:
             source_kind, excerpts = sources[claim.claim_type]
@@ -207,9 +231,9 @@ def normalize_analysis_item(
         claims.append(claim.model_copy(update={**claim_updates, **quote_updates}))
 
     claims_by_id = {claim.claim_id: claim for claim in claims}
-    item_updates: dict[str, object] = {"claims": claims}
+    item_updates: dict[str, object] = {"claims": claims, **block_updates}
     for name in ANALYSIS_BLOCK_NAMES:
-        block = getattr(item, name)
+        block = block_updates.get(name)
         if block is None:
             continue
         text = "".join(claims_by_id[claim_id].text for claim_id in block.claim_ids)

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -723,6 +723,31 @@ def test_analyst_result_is_evidence_verified_before_editing(tmp_path: Path) -> N
     assert normalized.claims[0].quotes == []
 
 
+def test_analysis_normalization_gives_reused_claims_stable_unique_ids(tmp_path: Path) -> None:
+    layout = SiteLayout(tmp_path)
+    layout.ensure()
+    snapshot = _snapshot(layout)
+    item = _standard_item("event-0", 0)
+    reused_id = item.headline_block.claim_ids[0]
+    reused = item.model_copy(
+        update={
+            "importance_block": item.importance_block.model_copy(
+                update={"text": item.headline_block.text, "claim_ids": [reused_id]}
+            )
+        }
+    )
+
+    normalized = normalize_analysis_item(reused, snapshot, _scope())
+    repeated = normalize_analysis_item(reused, snapshot, _scope())
+
+    verify_analysis_item(normalized, snapshot, _scope())
+    assert normalized.headline_block.claim_ids != normalized.importance_block.claim_ids
+    assert normalized == repeated
+    assert len(normalized.claims) == len(
+        {claim.claim_id for claim in normalized.claims}
+    )
+
+
 def test_verifier_rejects_fabricated_fact_labeled_as_inference(tmp_path: Path) -> None:
     config = load_config(Path("config")).persona
     assert config is not None


### PR DESCRIPTION
## Summary
- assign deterministic claim IDs per public block during analyst normalization
- preserve strict one-claim-to-one-block auditability without trusting model IDs
- add regression coverage for reused model claim IDs

## Verification
- `uv run pytest -q`
- `uv run ruff check src tests`
- `uv run mypy src`
- `git diff --check`