### PR TITLE
fix: complete persona plan audit inventory

### DIFF
--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -26,6 +26,7 @@ from ai_daily.persona_models import (
     Critique,
     EditionDraft,
     FinalizerOutput,
+    OmittedEvent,
     PersonaContext,
     PersonaEdition,
     PersonaPlan,
@@ -178,7 +179,7 @@ class PersonaPipeline:
             PersonaPlan,
             _planner_instructions(),
             prompt,
-            validator=lambda value: _validate_plan(value, context, event_rows),
+            validator=lambda value: _normalize_plan(value, context, event_rows),
             stage=BudgetStage.PERSONA,
         )
 
@@ -600,6 +601,32 @@ def _validate_plan(
     omitted = set(omitted_ids)
     if omitted != event_ids - selected_ids - set(plan.watchlist_event_ids):
         raise ValueError("persona plan omitted inventory is incomplete")
+
+
+def _normalize_plan(
+    plan: PersonaPlan,
+    context: PersonaContext,
+    rows: list[dict[str, Any]],
+) -> PersonaPlan:
+    """Fill only missing audit rows; selection remains entirely model-owned."""
+    selected = {item.event_id for item in plan.selections}
+    watchlist = set(plan.watchlist_event_ids)
+    listed = {item.event_id for item in plan.omitted}
+    missing = [
+        event_id
+        for event_id in context.candidate_event_ids
+        if event_id not in selected | watchlist | listed
+    ]
+    normalized = plan.model_copy(
+        update={
+            "omitted": [
+                *plan.omitted,
+                *(OmittedEvent(event_id=event_id, reason="capacity") for event_id in missing),
+            ]
+        }
+    )
+    _validate_plan(normalized, context, rows)
+    return normalized
 
 
 def _validate_analysis(

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -29,6 +29,7 @@ from ai_daily.persona_models import (
     FinalizerOutput,
     FinalizerResolution,
     OperationReceipt,
+    PersonaContext,
     PersonaEdition,
     PersonaPlan,
     PlanSelection,
@@ -42,6 +43,7 @@ from ai_daily.persona_pipeline import (
     PersonaPipeline,
     _analyst_event_row,
     _json_prompt,
+    _normalize_plan,
     _validate_critique,
     _validate_finalizer_changes,
 )
@@ -196,6 +198,45 @@ def test_analyst_prompt_drops_nested_raw_items_and_stays_bounded() -> None:
 
     assert "items" not in row["event"]
     assert len(prompt) <= 10_000
+
+
+def test_plan_normalization_completes_only_the_omitted_audit_inventory() -> None:
+    candidate_ids = ["event-0", "event-1", "event-2"]
+    context = PersonaContext(
+        target_date=TARGET,
+        upstream_marker="a" * 64,
+        constitution_sha256="b" * 64,
+        candidate_event_ids=candidate_ids,
+        retrieved_memories=[],
+    )
+    rows = [
+        {
+            "event": {"event_id": event_id},
+            "evidence": {"evidence": [{"evidence_id": f"{event_id}-1"}]},
+        }
+        for event_id in candidate_ids
+    ]
+    plan = PersonaPlan(
+        edition_type="standard",
+        today_thesis="这项变化值得 AI 产品团队今天处理。",
+        selections=[
+            PlanSelection(
+                event_id="event-0",
+                grade="S",
+                importance_reason="这项变化影响 AI 产品决策。",
+                evidence_ids=["event-0-1"],
+            )
+        ],
+        watchlist_event_ids=["event-1"],
+        omitted=[],
+    )
+
+    normalized = _normalize_plan(plan, context, rows)
+
+    assert normalized.selections == plan.selections
+    assert normalized.watchlist_event_ids == plan.watchlist_event_ids
+    assert [item.event_id for item in normalized.omitted] == ["event-2"]
+    assert normalized.omitted[0].reason == "capacity"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- deterministically add missing omitted-audit rows from the candidate inventory
- leave selections and watchlist entirely model-owned
- retain strict validation for unknown IDs, duplicates, evidence, and memory scope

## Verification
- `uv run pytest -q`
- `uv run ruff check src tests`
- `uv run mypy src`
- `git diff --check`