### PR TITLE
chore: extend persona request recovery headroom

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -22,7 +22,9 @@ ai_disclosure: 本文由 AI 参与资料整理和初稿生成，并经过证据�
 budget:
   # These are runaway backstops, not normal-run quotas. The ¥12 ceiling remains
   # binding before current DeepSeek pricing can consume these token allowances.
-  request_limit: 100
+  # Same-day recovery may accumulate schema retries that cost little or nothing;
+  # money remains the binding safety control.
+  request_limit: 120
   input_token_limit: 1500000
   # The persona gateway reserves the worst case before a call. Three concurrent
   # 48k-output calls with one schema retry can reserve 288k even though actual

--- a/src/ai_daily/models.py
+++ b/src/ai_daily/models.py
@@ -269,7 +269,7 @@ class RoleModelConfig(StrictModel):
 
 
 class BudgetConfig(StrictModel):
-    request_limit: int = Field(gt=0, le=100)
+    request_limit: int = Field(gt=0, le=200)
     input_token_limit: int = Field(gt=0)
     output_token_limit: int = Field(gt=0)
     cost_cny_limit: float = Field(gt=0)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -64,6 +64,13 @@ def test_normal_editorial_run_must_fit_model_request_budget() -> None:
         AppConfig.model_validate(value)
 
 
+def test_persona_recovery_request_budget_stays_within_schema_ceiling() -> None:
+    config = load_config(Path("config"))
+
+    assert config.persona is not None
+    assert config.persona.budget.request_limit == 120
+
+
 def test_huggingface_model_source_requires_namespace() -> None:
     with pytest.raises(ValidationError, match="require namespace"):
         SourceConfig(


### PR DESCRIPTION
## Summary
- raise only the persona same-day request backstop from 100 to 120
- allow configured budgets up to 200 requests while the base pipeline remains at 100
- keep the ¥12 cost hard stop unchanged

## Verification
- `uv run pytest -q`
- `uv run ruff check src tests`
- `uv run mypy src`
- `git diff --check`