### PR TITLE
fix: sanitize persona interpretation anchors

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -9,7 +9,7 @@ memory_limit: 16
 # retry while preserving every selected analysis.
 analyst_concurrency: 2
 # Minimum per-call reservation. The gateway raises this to the prompt/token
-# price ceiling (about ¥0.6-1.0 for current calls), while the ¥12 cap is absolute.
+# price ceiling (about ¥0.6-1.0 for current calls), while the ¥14 cap is absolute.
 max_call_cost_cny: 0.25
 baseline_window_days: 90
 evidence_retention_days: 120
@@ -20,7 +20,7 @@ no_major_max_chars: 600
 publish_mode: draft_only
 ai_disclosure: 本文由 AI 参与资料整理和初稿生成，并经过证据约束与自动审稿。
 budget:
-  # These are runaway backstops, not normal-run quotas. The ¥12 ceiling remains
+  # These are runaway backstops, not normal-run quotas. The ¥14 ceiling remains
   # binding before current DeepSeek pricing can consume these token allowances.
   # Same-day recovery may accumulate schema retries that cost little or nothing;
   # money remains the binding safety control.
@@ -28,8 +28,8 @@ budget:
   input_token_limit: 1500000
   # The persona gateway reserves the worst case before a call. Three concurrent
   # 48k-output calls with one schema retry can reserve 288k even though actual
-  # usage is much lower. Keep tokens non-binding and let the ¥12 ceiling stop spend.
-  output_token_limit: 1500000
+  # usage is much lower. Keep tokens non-binding and let the ¥14 ceiling stop spend.
+  output_token_limit: 1800000
   # Fresh successful editions are expected to stay around ¥1-2. The higher hard
   # stop preserves same-day recovery after charged provider or validation failures.
-  cost_cny_limit: 12.0
+  cost_cny_limit: 14.0

--- a/src/ai_daily/persona_verifier.py
+++ b/src/ai_daily/persona_verifier.py
@@ -221,13 +221,13 @@ def normalize_analysis_item(
             claim_updates["text"] = "；".join(quote.quote for quote in quotes)
         elif (prefix := INTERPRETIVE_PREFIX.get(claim.claim_type)) is not None:
             quote_updates = {"quotes": []}
-            text = claim.text
-            for token in sorted(
-                set(ANCHOR_RE.findall(text.removeprefix(prefix))), key=len, reverse=True
-            ):
-                replacement = "相关指标" if token[0].isdigit() else "相关版本"
-                text = text.replace(token, replacement)
-            claim_updates["text"] = text
+            body = ANCHOR_RE.sub(
+                lambda match: "相关指标"
+                if match.group(0)[0].isdigit()
+                else "相关版本",
+                claim.text.removeprefix(prefix),
+            )
+            claim_updates["text"] = prefix + body
         claims.append(claim.model_copy(update={**claim_updates, **quote_updates}))
 
     claims_by_id = {claim.claim_id: claim for claim in claims}

--- a/tests/test_budget_staging.py
+++ b/tests/test_budget_staging.py
@@ -172,7 +172,7 @@ def test_persona_budget_can_retry_configured_analysts_after_charged_failures() -
 
     assert ledger.reserved_requests == 4
     assert ledger.reserved_output_tokens == 192_000
-    assert ledger.remaining_cost() == pytest.approx(3.864466)
+    assert ledger.remaining_cost() == pytest.approx(5.864466)
 
 
 def test_stage_totals_are_reported_separately(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- sanitize numeric/version anchors in interpretive claims with direct regex substitution
- reconstruct the required interpretive prefix deterministically
- extend same-day recovery cost/token backstops after conservative cancelled-call accounting

## Safety
- factual blocks remain exact evidence-derived quotes
- strict evidence verification remains enabled
- actual spend remains hard-capped at ¥14

## Verification
- `uv run pytest -q`
- `uv run ruff check src tests`
- `uv run mypy src`
- `git diff --check`