### PR TITLE
fix: retry transient primary model failures

### DIFF
--- a/src/ai_daily/model_gateway.py
+++ b/src/ai_daily/model_gateway.py
@@ -96,7 +96,8 @@ class ModelGateway:
     ) -> OutputT:
         role_config = self.config.roles[role]
         fallback_reason: str | None = None
-        for attempt, endpoint in enumerate((role_config.primary, role_config.fallback), start=1):
+        endpoints = (role_config.primary, role_config.primary, role_config.fallback)
+        for attempt, endpoint in enumerate(endpoints, start=1):
             invocation = Invocation(role, role_config.primary, endpoint, attempt, fallback_reason)
             try:
                 return await self._invoke_endpoint(
@@ -110,7 +111,7 @@ class ModelGateway:
             except (BudgetExceeded, UsageLimitExceeded, MissingProviderSecret):
                 raise
             except Exception as error:
-                if attempt == 1 and is_recoverable(error):
+                if attempt < len(endpoints) and is_recoverable(error):
                     fallback_reason = self._safe_error(error)
                     continue
                 raise ModelInvocationFailed(self._safe_error(error)) from error

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -27,7 +27,7 @@ def test_only_transient_failures_are_recoverable() -> None:
     assert not is_recoverable(ModelHTTPError(400, "model"))
 
 
-async def test_generate_falls_back_after_pydantic_ai_wrapped_timeout(
+async def test_generate_retries_primary_after_pydantic_ai_wrapped_timeout(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     gateway = ModelGateway(load_config().models, Secrets())
@@ -62,7 +62,7 @@ async def test_generate_falls_back_after_pydantic_ai_wrapped_timeout(
     role = gateway.config.roles["judge"]
     assert [call.endpoint.provider for call in calls] == [
         role.primary.provider,
-        role.fallback.provider,
+        role.primary.provider,
     ]
     assert calls[1].fallback_reason == "ModelAPIError"
 
@@ -123,7 +123,7 @@ def test_fallback_audit_preserves_requested_model() -> None:
             role="judge",
             requested=role.primary,
             endpoint=role.fallback,
-            attempt=2,
+            attempt=3,
             fallback_reason="ModelHTTPError:503",
         ),
         1.0,
@@ -151,7 +151,7 @@ async def test_generate_falls_back_only_after_a_recoverable_failure(
         stage: object = None,
     ) -> JudgeDecision:
         calls.append(invocation)
-        if invocation.attempt == 1:
+        if invocation.attempt < 3:
             raise httpx.ReadTimeout("timeout")
         return JudgeDecision(
             event_id="event-1",
@@ -170,9 +170,11 @@ async def test_generate_falls_back_only_after_a_recoverable_failure(
     assert result.event_id == "event-1"
     assert [call.endpoint for call in calls] == [
         gateway.config.roles["judge"].primary,
+        gateway.config.roles["judge"].primary,
         gateway.config.roles["judge"].fallback,
     ]
     assert calls[1].fallback_reason.startswith("ReadTimeout")
+    assert calls[2].fallback_reason.startswith("ReadTimeout")
 
 
 async def test_generate_does_not_fallback_after_unrecoverable_error(


### PR DESCRIPTION
## Summary
- retry the primary provider once after a recoverable connection/API failure
- fall back cross-provider only after both primary attempts fail
- preserve immediate failure for auth, validation, and budget errors

## Verification
- `uv run pytest -q`
- `uv run ruff check src tests`
- `uv run mypy src`
- `git diff --check`