### PR TITLE
fix: exhaust adjacent persona anchors

### DIFF
--- a/src/ai_daily/persona_verifier.py
+++ b/src/ai_daily/persona_verifier.py
@@ -221,12 +221,14 @@ def normalize_analysis_item(
             claim_updates["text"] = "；".join(quote.quote for quote in quotes)
         elif (prefix := INTERPRETIVE_PREFIX.get(claim.claim_type)) is not None:
             quote_updates = {"quotes": []}
-            body = ANCHOR_RE.sub(
-                lambda match: "相关指标"
-                if match.group(0)[0].isdigit()
-                else "相关版本",
-                claim.text.removeprefix(prefix),
-            )
+            body = claim.text.removeprefix(prefix)
+            while ANCHOR_RE.search(body):
+                body = ANCHOR_RE.sub(
+                    lambda match: "相关指标"
+                    if match.group(0)[0].isdigit()
+                    else "相关版本",
+                    body,
+                )
             claim_updates["text"] = prefix + body
         claims.append(claim.model_copy(update={**claim_updates, **quote_updates}))
 

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -730,7 +730,7 @@ def test_analyst_result_is_evidence_verified_before_editing(tmp_path: Path) -> N
     wrong_path = item.claims[0].model_copy(
         update={
             "field_path": "items[1].headline_block",
-            "text": "判断：GPT-6 将成本降低 90%。",
+            "text": "判断：1V2、GPT-6 将成本降低 90%。",
             "quotes": [
                 ClaimQuote(
                     source_kind="current_evidence",
@@ -760,6 +760,7 @@ def test_analyst_result_is_evidence_verified_before_editing(tmp_path: Path) -> N
     assert normalized.claims[1].quotes[0].quote == QUOTE
     assert normalized.claims[0].field_path == "items[0].headline_block"
     assert "GPT-6" not in normalized.claims[0].text
+    assert "V2" not in normalized.claims[0].text
     assert "90%" not in normalized.claims[0].text
     assert normalized.claims[0].quotes == []
 


### PR DESCRIPTION
## Summary
- repeatedly sanitize interpretive numeric/version anchors until no match remains
- cover adjacent `1V2` anchors that become matchable only after the first substitution
- retain the strict post-normalization grounding verifier

## Verification
- `uv run pytest -q`
- `uv run ruff check src tests`
- `uv run mypy src`
- `git diff --check`