### PR TITLE
chore: finalize persona recovery headroom

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -9,7 +9,7 @@ memory_limit: 16
 # retry while preserving every selected analysis.
 analyst_concurrency: 2
 # Minimum per-call reservation. The gateway raises this to the prompt/token
-# price ceiling (about ¥0.6-1.0 for current calls), while the ¥14 cap is absolute.
+# price ceiling (about ¥0.6-1.0 for current calls), while the ¥16 cap is absolute.
 max_call_cost_cny: 0.25
 baseline_window_days: 90
 evidence_retention_days: 120
@@ -20,16 +20,16 @@ no_major_max_chars: 600
 publish_mode: draft_only
 ai_disclosure: 本文由 AI 参与资料整理和初稿生成，并经过证据约束与自动审稿。
 budget:
-  # These are runaway backstops, not normal-run quotas. The ¥14 ceiling remains
+  # These are runaway backstops, not normal-run quotas. The ¥16 ceiling remains
   # binding before current DeepSeek pricing can consume these token allowances.
   # Same-day recovery may accumulate schema retries that cost little or nothing;
   # money remains the binding safety control.
-  request_limit: 120
+  request_limit: 140
   input_token_limit: 1500000
   # The persona gateway reserves the worst case before a call. Three concurrent
   # 48k-output calls with one schema retry can reserve 288k even though actual
-  # usage is much lower. Keep tokens non-binding and let the ¥14 ceiling stop spend.
-  output_token_limit: 1800000
+  # usage is much lower. Keep tokens non-binding and let the ¥16 ceiling stop spend.
+  output_token_limit: 2100000
   # Fresh successful editions are expected to stay around ¥1-2. The higher hard
   # stop preserves same-day recovery after charged provider or validation failures.
-  cost_cny_limit: 14.0
+  cost_cny_limit: 16.0

--- a/tests/test_budget_staging.py
+++ b/tests/test_budget_staging.py
@@ -172,7 +172,7 @@ def test_persona_budget_can_retry_configured_analysts_after_charged_failures() -
 
     assert ledger.reserved_requests == 4
     assert ledger.reserved_output_tokens == 192_000
-    assert ledger.remaining_cost() == pytest.approx(5.864466)
+    assert ledger.remaining_cost() == pytest.approx(7.864466)
 
 
 def test_stage_totals_are_reported_separately(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,7 +68,7 @@ def test_persona_recovery_request_budget_stays_within_schema_ceiling() -> None:
     config = load_config(Path("config"))
 
     assert config.persona is not None
-    assert config.persona.budget.request_limit == 120
+    assert config.persona.budget.request_limit == 140
 
 
 def test_huggingface_model_source_requires_namespace() -> None:


### PR DESCRIPTION
## Summary
- extend same-day production recovery ceilings to ¥16, 140 requests, and 2.1M output tokens
- retain cost as the binding hard stop
- update exact configuration and budget regression assertions

## Context
Conservative accounting for repeated validation and cancelled calls consumed the lower recovery ceilings while implementing the first production edition. Fresh editions remain expected at ¥1–2.

## Verification
- `uv run pytest -q`
- `uv run ruff check src tests`
- `uv run mypy src`
- `git diff --check`