### PR TITLE
fix: settle persisted fractional reservations

### DIFF
--- a/src/ai_daily/budget.py
+++ b/src/ai_daily/budget.py
@@ -51,6 +51,12 @@ STAGE_SHARE: dict[BudgetStage, float] = {
     # Persona uses a separate ledger and owns its full configured allowance.
     BudgetStage.PERSONA: 1.0,
 }
+RESERVATION_COST_TOLERANCE = 1e-6
+
+
+def _subtract_reserved_cost(total: float, amount: float) -> float:
+    remainder = total - amount
+    return 0.0 if remainder <= RESERVATION_COST_TOLERANCE else remainder
 
 
 def _empty_stage_ints() -> dict[str, int]:
@@ -124,17 +130,15 @@ class BudgetLedger:
             "requests": self.requests,
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
-            "cost_cny": round(self.cost_cny, 6),
+            "cost_cny": self.cost_cny,
             "stage_requests": dict(self.stage_requests),
-            "stage_cost": {key: round(value, 6) for key, value in self.stage_cost.items()},
+            "stage_cost": dict(self.stage_cost),
             "reserved_requests": self.reserved_requests,
             "reserved_input_tokens": self.reserved_input_tokens,
             "reserved_output_tokens": self.reserved_output_tokens,
-            "reserved_cost_cny": round(self.reserved_cost_cny, 6),
+            "reserved_cost_cny": self.reserved_cost_cny,
             "stage_reserved_requests": dict(self.stage_reserved_requests),
-            "stage_reserved_cost": {
-                key: round(value, 6) for key, value in self.stage_reserved_cost.items()
-            },
+            "stage_reserved_cost": dict(self.stage_reserved_cost),
             "runs_today": self.runs_today,
         }
         self.store_path.parent.mkdir(parents=True, exist_ok=True)
@@ -281,7 +285,8 @@ class BudgetLedger:
         with self._transaction():
             if (
                 requests > self.stage_reserved_requests[stage.value]
-                or cost_cny > self.stage_reserved_cost[stage.value] + 1e-9
+                or cost_cny
+                > self.stage_reserved_cost[stage.value] + RESERVATION_COST_TOLERANCE
                 or input_tokens > self.reserved_input_tokens
                 or output_tokens > self.reserved_output_tokens
             ):
@@ -289,9 +294,13 @@ class BudgetLedger:
             self.reserved_requests -= requests
             self.reserved_input_tokens -= input_tokens
             self.reserved_output_tokens -= output_tokens
-            self.reserved_cost_cny -= cost_cny
+            self.reserved_cost_cny = _subtract_reserved_cost(
+                self.reserved_cost_cny, cost_cny
+            )
             self.stage_reserved_requests[stage.value] -= requests
-            self.stage_reserved_cost[stage.value] -= cost_cny
+            self.stage_reserved_cost[stage.value] = _subtract_reserved_cost(
+                self.stage_reserved_cost[stage.value], cost_cny
+            )
 
     def settle_reservation(
         self,
@@ -306,7 +315,8 @@ class BudgetLedger:
         with self._transaction():
             if (
                 requests > self.stage_reserved_requests[stage.value]
-                or cost_cny > self.stage_reserved_cost[stage.value] + 1e-9
+                or cost_cny
+                > self.stage_reserved_cost[stage.value] + RESERVATION_COST_TOLERANCE
                 or input_tokens > self.reserved_input_tokens
                 or output_tokens > self.reserved_output_tokens
             ):
@@ -314,9 +324,13 @@ class BudgetLedger:
             self.reserved_requests -= requests
             self.reserved_input_tokens -= input_tokens
             self.reserved_output_tokens -= output_tokens
-            self.reserved_cost_cny -= cost_cny
+            self.reserved_cost_cny = _subtract_reserved_cost(
+                self.reserved_cost_cny, cost_cny
+            )
             self.stage_reserved_requests[stage.value] -= requests
-            self.stage_reserved_cost[stage.value] -= cost_cny
+            self.stage_reserved_cost[stage.value] = _subtract_reserved_cost(
+                self.stage_reserved_cost[stage.value], cost_cny
+            )
             self.requests += actual_requests
             self.input_tokens += run.input_tokens
             self.output_tokens += run.output_tokens

--- a/tests/test_budget_ledger.py
+++ b/tests/test_budget_ledger.py
@@ -206,6 +206,46 @@ def test_stale_ledger_instances_cannot_overwrite_each_others_reservations(
     assert persisted.reserved_output_tokens == 50
 
 
+def test_persisted_fractional_reservations_settle_without_rounding_drift(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    config = factories.budget_config(request_limit=20, cost_cny_limit=5)
+    ledger = _ledger(store, config)
+    first_cost = 0.6272326
+    second_cost = 0.6206486
+    for cost in (first_cost, second_cost):
+        ledger.reserve(
+            BudgetStage.PERSONA,
+            2,
+            cost,
+            input_tokens=100,
+            output_tokens=50,
+        )
+
+    ledger.settle_reservation(
+        BudgetStage.PERSONA,
+        2,
+        first_cost,
+        100,
+        50,
+        _run(0.1),
+    )
+    ledger.settle_reservation(
+        BudgetStage.PERSONA,
+        2,
+        second_cost,
+        100,
+        50,
+        _run(0.1),
+    )
+
+    persisted = _ledger(store, config)
+    assert persisted.reserved_requests == 0
+    assert persisted.reserved_cost_cny == 0
+    assert persisted.stage_reserved_cost[BudgetStage.PERSONA.value] == 0
+
+
 def test_next_run_conservatively_charges_orphaned_reservations(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- persist internal budget costs at full precision
- tolerate legacy six-decimal reservation drift during settlement
- clamp sub-tolerance floating remainders to zero
- add a two-reservation/two-settlement regression matching production decimals

## Verification
- `uv run pytest -q`
- `uv run ruff check src tests`
- `uv run mypy src`
- `git diff --check`