### PR TITLE
Safely resume verified persona analysis runs

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -9,7 +9,7 @@ memory_limit: 16
 # retry while preserving every selected analysis.
 analyst_concurrency: 2
 # Minimum per-call reservation. The gateway raises this to the prompt/token
-# price ceiling (about ¥0.6-1.0 for current calls), while the ¥16 cap is absolute.
+# price ceiling (about ¥0.6-1.0 for current calls), while the ¥18 cap is absolute.
 max_call_cost_cny: 0.25
 baseline_window_days: 90
 evidence_retention_days: 120
@@ -20,16 +20,16 @@ no_major_max_chars: 600
 publish_mode: draft_only
 ai_disclosure: 本文由 AI 参与资料整理和初稿生成，并经过证据约束与自动审稿。
 budget:
-  # These are runaway backstops, not normal-run quotas. The ¥16 ceiling remains
+  # These are runaway backstops, not normal-run quotas. The ¥18 ceiling remains
   # binding before current DeepSeek pricing can consume these token allowances.
   # Same-day recovery may accumulate schema retries that cost little or nothing;
   # money remains the binding safety control.
   request_limit: 140
   input_token_limit: 1500000
-  # The persona gateway reserves the worst case before a call. Three concurrent
-  # 48k-output calls with one schema retry can reserve 288k even though actual
-  # usage is much lower. Keep tokens non-binding and let the ¥16 ceiling stop spend.
+  # The persona gateway reserves the worst case before a call. Two concurrent
+  # 48k-output calls with one schema retry can reserve 192k even though actual
+  # usage is much lower. Keep tokens non-binding and let the ¥18 ceiling stop spend.
   output_token_limit: 2100000
   # Fresh successful editions are expected to stay around ¥1-2. The higher hard
   # stop preserves same-day recovery after charged provider or validation failures.
-  cost_cny_limit: 16.0
+  cost_cny_limit: 18.0

--- a/src/ai_daily/cli.py
+++ b/src/ai_daily/cli.py
@@ -390,7 +390,7 @@ async def _persona_run_unlocked(args: argparse.Namespace) -> int:
             Path(args.config_dir).resolve().parent,
             target,
         )
-        result = await pipeline.run(target)
+        result = await pipeline.run(target, getattr(args, "resume_run", None))
         if result.editorial_state == "held":
             write_persona_status(layout, result.model_dump(mode="json"))
             _emit(result.model_dump(mode="json"))
@@ -581,6 +581,11 @@ def build_parser() -> argparse.ArgumentParser:
     persona.add_argument("--mode", choices=("dry-run", "site", "draft"), required=True)
     persona.add_argument("--authorization", type=Path)
     persona.add_argument("--execute", action="store_true")
+    persona.add_argument(
+        "--resume-run",
+        type=Path,
+        help="reuse a verified run that has no historical baseline match",
+    )
 
     persona_daily = subparsers.add_parser("persona-daily", help="stable-marker timer entry")
     persona_daily.add_argument("--date")
@@ -588,6 +593,11 @@ def build_parser() -> argparse.ArgumentParser:
     persona_daily.add_argument("--authorization", type=Path)
     persona_daily.add_argument("--execute", action="store_true")
     persona_daily.add_argument("--stability-seconds", type=int, default=30)
+    persona_daily.add_argument(
+        "--resume-run",
+        type=Path,
+        help="reuse a verified run that has no historical baseline match",
+    )
 
     wechat_probe = subparsers.add_parser("wechat-probe", help="probe read-only capabilities")
     wechat_probe.add_argument("--date")

--- a/src/ai_daily/persona_models.py
+++ b/src/ai_daily/persona_models.py
@@ -126,6 +126,7 @@ class PersonaContext(StrictModel):
     target_date: date
     upstream_marker: str = Field(pattern=r"^[a-f0-9]{64}$")
     constitution_sha256: str = Field(pattern=r"^[a-f0-9]{64}$")
+    memory_context_sha256: str | None = Field(default=None, pattern=r"^[a-f0-9]{64}$")
     candidate_event_ids: list[str] = Field(max_length=30)
     retrieved_memories: list[RetrievedMemory] = Field(max_length=16)
     has_conflicts: bool = False

--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -23,6 +23,7 @@ from ai_daily.persona_memory import (
 from ai_daily.persona_models import (
     AnalysisItem,
     AnalystOutput,
+    BaselineMatch,
     Critique,
     EditionDraft,
     FinalizerOutput,
@@ -40,6 +41,7 @@ from ai_daily.persona_snapshot import load_upstream_snapshot
 from ai_daily.persona_verifier import (
     VerificationScope,
     normalize_analysis_item,
+    normalize_edition_draft,
     verify_analysis_item,
     verify_edition,
 )
@@ -80,11 +82,18 @@ class PersonaPipeline:
             reservation_cost_cny=self.persona.max_call_cost_cny,
         )
 
-    async def run(self, target_date: date) -> PersonaRunResult:
+    async def run(
+        self,
+        target_date: date,
+        resume_run_dir: Path | None = None,
+    ) -> PersonaRunResult:
         run_dir = self._run_dir(target_date)
         self.gateway.ledger.start_run(recover_stale_reservations=True)
         try:
-            edition = await self._produce(target_date, run_dir)
+            if resume_run_dir is None:
+                edition = await self._produce(target_date, run_dir)
+            else:
+                edition = await self._produce(target_date, run_dir, resume_run_dir)
             with publication_lock(self.layout):
                 active = load_upstream_snapshot(self.layout, target_date)
                 if active.publication_marker != edition.input_marker:
@@ -110,7 +119,12 @@ class PersonaPipeline:
         write_artifact(run_dir / "result.json", result)
         return result
 
-    async def _produce(self, target_date: date, run_dir: Path) -> PersonaEdition:
+    async def _produce(
+        self,
+        target_date: date,
+        run_dir: Path,
+        resume_run_dir: Path | None = None,
+    ) -> PersonaEdition:
         snapshot = load_upstream_snapshot(self.layout, target_date)
         if snapshot.publication_level not in {PublicationLevel.L0, PublicationLevel.L1}:
             raise ValueError(f"upstream level {snapshot.publication_level.value} is not authorized")
@@ -124,6 +138,7 @@ class PersonaPipeline:
             constitution_sha256=constitution_hash(
                 self.project_root / self.persona.constitution_path
             ),
+            memory_context_sha256=_memory_context_sha256(retrieved[0], memories),
             candidate_event_ids=shortlist.event_ids,
             retrieved_memories=retrieved[0],
             has_conflicts=retrieved[1],
@@ -131,6 +146,39 @@ class PersonaPipeline:
         write_artifact(run_dir / "context.json", context)
         if context.has_conflicts:
             raise ValueError("retrieved editorial memories contain an unresolved conflict")
+        plan, analyses, scope = await self._analysis_stage(
+            run_dir,
+            snapshot,
+            context,
+            memories,
+            resume_run_dir,
+        )
+        draft = await self._edit(snapshot, plan, analyses, scope)
+        write_artifact(run_dir / "draft.json", draft)
+        final = await self._review(snapshot, draft, scope, run_dir)
+        return verify_edition(final, snapshot, scope, self.persona)
+
+    async def _analysis_stage(
+        self,
+        run_dir: Path,
+        snapshot: Any,
+        context: PersonaContext,
+        memories: dict[str, Any],
+        resume_run_dir: Path | None,
+    ) -> tuple[PersonaPlan, list[AnalysisItem], VerificationScope]:
+        if resume_run_dir is None:
+            return await self._fresh_analysis(run_dir, snapshot, context, memories)
+        plan, analyses, scope = self._resume_analysis(resume_run_dir, snapshot, context, memories)
+        self._write_resumed_analysis(run_dir, resume_run_dir, plan, analyses)
+        return plan, analyses, scope
+
+    async def _fresh_analysis(
+        self,
+        run_dir: Path,
+        snapshot: Any,
+        context: PersonaContext,
+        memories: dict[str, Any],
+    ) -> tuple[PersonaPlan, list[AnalysisItem], VerificationScope]:
         plan = await self._plan(snapshot, context, memories)
         write_artifact(run_dir / "plan.json", plan)
         baselines, baseline_map = await resolve_baselines(
@@ -147,10 +195,81 @@ class PersonaPipeline:
         scope = _verification_scope(snapshot, plan, baselines, memories, baseline_map)
         analyses = await self._analyze(snapshot, plan, memories, baselines, scope)
         write_artifact(run_dir / "analyses.json", analyses)
-        draft = await self._edit(snapshot, plan, analyses, scope)
-        write_artifact(run_dir / "draft.json", draft)
-        final = await self._review(snapshot, draft, scope, run_dir)
-        return verify_edition(final, snapshot, scope, self.persona)
+        return plan, analyses, scope
+
+    @staticmethod
+    def _write_resumed_analysis(
+        run_dir: Path,
+        source_run_dir: Path,
+        plan: PersonaPlan,
+        analyses: list[AnalysisItem],
+    ) -> None:
+        write_artifact(run_dir / "plan.json", plan)
+        write_artifact(run_dir / "baselines.json", {})
+        write_artifact(run_dir / "analyses.json", analyses)
+        write_artifact(
+            run_dir / "resume.json",
+            {
+                "source_run_dir": str(source_run_dir.resolve()),
+                "plan_sha256": sha256_payload(plan.model_dump(mode="json")),
+                "analyses_sha256": sha256_payload(
+                    [item.model_dump(mode="json") for item in analyses]
+                ),
+            },
+        )
+
+    def _resume_analysis(
+        self,
+        source_run_dir: Path,
+        snapshot: Any,
+        context: PersonaContext,
+        memories: dict[str, Any],
+    ) -> tuple[PersonaPlan, list[AnalysisItem], VerificationScope]:
+        source = source_run_dir.resolve()
+        expected_parent = (self.layout.persona_runs / context.target_date.isoformat()).resolve()
+        if source.parent != expected_parent or not source.is_dir():
+            raise ValueError("resume run must be an existing run for the target date")
+        prior_context = PersonaContext.model_validate_json(
+            (source / "context.json").read_text(encoding="utf-8")
+        )
+        if prior_context.memory_context_sha256 is None:
+            raise ValueError("resume context lacks a memory-content attestation")
+        if prior_context != context:
+            raise ValueError("resume context no longer matches current inputs")
+        plan = PersonaPlan.model_validate_json((source / "plan.json").read_text(encoding="utf-8"))
+        _validate_plan(plan, context, _planner_event_rows(snapshot, context.candidate_event_ids))
+        raw_baselines = json.loads((source / "baselines.json").read_text(encoding="utf-8"))
+        baselines = {
+            key: BaselineMatch.model_validate(value) for key, value in raw_baselines.items()
+        }
+        if baselines:
+            raise ValueError("resume source has historical baselines without evidence artifacts")
+        analyses = [
+            AnalysisItem.model_validate(value)
+            for value in json.loads((source / "analyses.json").read_text(encoding="utf-8"))
+        ]
+        scope = _verification_scope(snapshot, plan, baselines, memories, {})
+        self._verify_resumed_analyses(plan, analyses, snapshot, scope)
+        return plan, analyses, scope
+
+    @staticmethod
+    def _verify_resumed_analyses(
+        plan: PersonaPlan,
+        analyses: list[AnalysisItem],
+        snapshot: Any,
+        scope: VerificationScope,
+    ) -> None:
+        selections = [item for item in plan.selections if item.grade in {"S", "A"}]
+        if len(analyses) != len(selections):
+            raise ValueError("resume analyses do not cover every S/A selection")
+        for selection, item in zip(selections, analyses, strict=True):
+            if item.event_id != selection.event_id or item.grade != selection.grade:
+                raise ValueError("resume analysis order or grade does not match the plan")
+            if not set(item.evidence_ids) <= set(selection.evidence_ids):
+                raise ValueError("resume analysis added evidence outside the plan")
+            if not set(item.memory_ids) <= set(selection.memory_ids):
+                raise ValueError("resume analysis added memory outside the plan")
+            verify_analysis_item(item, snapshot, scope)
 
     def _memory_context(
         self, events: list[Any], target_date: date
@@ -279,9 +398,11 @@ class PersonaPipeline:
             sources=_edition_source_rows(snapshot, plan),
         )
 
-        def validate(value: EditionDraft) -> None:
-            _validate_draft_identity(value, snapshot, plan, analyses, self.persona.column_id)
-            verify_edition(value, snapshot, scope, self.persona)
+        def validate(value: EditionDraft) -> EditionDraft:
+            normalized = normalize_edition_draft(value, scope)
+            _validate_draft_identity(normalized, snapshot, plan, analyses, self.persona.column_id)
+            verify_edition(normalized, snapshot, scope, self.persona)
+            return normalized
 
         return await self.gateway.generate(
             "persona_edition_editor",
@@ -304,13 +425,17 @@ class PersonaPipeline:
         if not first.open_blockers:
             return draft
 
-        def validate_finalizer(value: FinalizerOutput) -> None:
-            verify_edition(value.draft, snapshot, scope, self.persona)
+        def validate_finalizer(value: FinalizerOutput) -> FinalizerOutput:
+            normalized = value.model_copy(
+                update={"draft": normalize_edition_draft(value.draft, scope)}
+            )
+            verify_edition(normalized.draft, snapshot, scope, self.persona)
             expected = {item.blocker_id for item in first.open_blockers}
-            actual = {item.blocker_id for item in value.resolutions}
-            if actual != expected or len(actual) != len(value.resolutions):
+            actual = {item.blocker_id for item in normalized.resolutions}
+            if actual != expected or len(actual) != len(normalized.resolutions):
                 raise ValueError("finalizer must resolve each blocker exactly once")
-            _validate_finalizer_changes(draft, value)
+            _validate_finalizer_changes(draft, normalized)
+            return normalized
 
         finalized = await self.gateway.generate(
             "persona_finalizer",
@@ -788,3 +913,16 @@ def _verification_scope(
             selection.event_id: set(selection.memory_ids) for selection in plan.selections
         },
     )
+
+
+def _memory_context_sha256(
+    retrieved: list[RetrievedMemory],
+    memories: dict[str, Any],
+) -> str:
+    try:
+        payload = {
+            item.memory_id: memories[item.memory_id].model_dump(mode="json") for item in retrieved
+        }
+    except KeyError as error:
+        raise ValueError(f"retrieved memory is missing: {error.args[0]}") from error
+    return sha256_payload(payload)

--- a/src/ai_daily/persona_verifier.py
+++ b/src/ai_daily/persona_verifier.py
@@ -20,7 +20,16 @@ from ai_daily.persona_models import (
     sha256_payload,
 )
 
-FIRST_PERSON_RE = re.compile(r"(?:^|[^你他她它])(?:我|我的|我们|咱们|本人)")
+COLLECTIVE_VOICE_REPLACEMENTS = {
+    "我们": "产品团队",
+    "咱们": "产品团队",
+}
+COLLECTIVE_VOICE_PATTERN = "|".join(
+    re.escape(value) for value in sorted(COLLECTIVE_VOICE_REPLACEMENTS, key=len, reverse=True)
+)
+FIRST_PERSON_RE = re.compile(rf"(?:{COLLECTIVE_VOICE_PATTERN}|我的|本人|我)")
+NON_AUTHOR_FIRST_PERSON_RE = re.compile(r"(?:忘我|无我|自我)")
+COLLECTIVE_VOICE_RE = re.compile(COLLECTIVE_VOICE_PATTERN)
 FORBIDDEN_STYLE_RE = re.compile(
     r"(?:颠覆一切|震撼发布|炸裂|王炸|遥遥领先|史诗级|必然取代|彻底改变世界)"
 )
@@ -78,7 +87,7 @@ def verify_edition(
         _verify_block(path, block, claims)
         if FORBIDDEN_STYLE_RE.search(block.text):
             raise ValueError(f"forbidden hype at {path}")
-        if FIRST_PERSON_RE.search(block.text) and not _first_person_allowed(
+        if _contains_first_person(block.text) and not _first_person_allowed(
             block, claims, scope.memories
         ):
             raise ValueError(f"unapproved first-person voice at {path}")
@@ -139,6 +148,77 @@ def verify_analysis_item(
             raise ValueError(f"item {item.event_id} delta lacks current or baseline evidence")
 
 
+def normalize_edition_draft(
+    draft: EditionDraft,
+    scope: VerificationScope,
+) -> EditionDraft:
+    """Remove unapproved author voice from interpretive claims, then rebuild blocks."""
+    claims = _claim_map(draft.claims)
+    normalized: dict[str, AnalysisClaim] = {}
+    block_updates: dict[str, PublicTextBlock] = {}
+    for path, block in _blocks(draft):
+        for claim_id in block.claim_ids:
+            try:
+                claim = claims[claim_id]
+            except KeyError as error:
+                raise ValueError(f"unknown claim id at {path}: {claim_id}") from error
+            text = claim.text
+            if claim.claim_type in INTERPRETIVE_PREFIX:
+                text = _neutralize_collective_voice(text)
+            normalized[claim_id] = claim.model_copy(update={"text": text})
+        block_updates[path] = block.model_copy(
+            update={"text": "".join(normalized[item].text for item in block.claim_ids)}
+        )
+    return _rebuild_edition(draft, normalized, block_updates)
+
+
+def _neutralize_collective_voice(text: str) -> str:
+    return COLLECTIVE_VOICE_RE.sub(
+        lambda match: COLLECTIVE_VOICE_REPLACEMENTS[match.group(0)], text
+    )
+
+
+def _contains_first_person(text: str) -> bool:
+    """Detect author voice after removing a small set of exact non-pronoun words."""
+    return FIRST_PERSON_RE.search(NON_AUTHOR_FIRST_PERSON_RE.sub("", text)) is not None
+
+
+def _rebuild_edition(
+    draft: EditionDraft,
+    claims: dict[str, AnalysisClaim],
+    blocks: dict[str, PublicTextBlock],
+) -> EditionDraft:
+    items: list[AnalysisItem] = []
+    for index, item in enumerate(draft.items):
+        try:
+            item_claims = [claims[claim.claim_id] for claim in item.claims]
+        except KeyError as error:
+            raise ValueError(
+                f"item {item.event_id} referenced unknown claim {error.args[0]}"
+            ) from error
+        updates: dict[str, object] = {"claims": item_claims}
+        for name in ANALYSIS_BLOCK_NAMES:
+            if getattr(item, name) is not None:
+                updates[name] = blocks[f"items[{index}].{name}"]
+        items.append(item.model_copy(update=updates))
+    try:
+        draft_claims = [claims[claim.claim_id] for claim in draft.claims]
+    except KeyError as error:
+        raise ValueError(f"unreferenced edition claim {error.args[0]}") from error
+    return draft.model_copy(
+        update={
+            "title_block": blocks["title_block"],
+            "digest_block": blocks["digest_block"],
+            "thesis_block": blocks["thesis_block"],
+            "items": items,
+            "watchlist_blocks": [
+                blocks[f"watchlist_blocks[{index}]"] for index in range(len(draft.watchlist_blocks))
+            ],
+            "claims": draft_claims,
+        }
+    )
+
+
 def normalize_analysis_item(
     item: AnalysisItem,
     snapshot: UpstreamSnapshot,
@@ -159,19 +239,20 @@ def normalize_analysis_item(
                 template = claim_templates[claim_id]
             except KeyError as error:
                 raise ValueError(f"unknown claim id at {path}: {claim_id}") from error
-            canonical_id = "claim-" + sha256_payload(
-                {
-                    "event_id": item.event_id,
-                    "field_path": path,
-                    "position": position,
-                    "source_claim_id": claim_id,
-                }
-            )[:20]
+            canonical_id = (
+                "claim-"
+                + sha256_payload(
+                    {
+                        "event_id": item.event_id,
+                        "field_path": path,
+                        "position": position,
+                        "source_claim_id": claim_id,
+                    }
+                )[:20]
+            )
             canonical_ids.append(canonical_id)
             claims_to_normalize.append(
-                template.model_copy(
-                    update={"claim_id": canonical_id, "field_path": path}
-                )
+                template.model_copy(update={"claim_id": canonical_id, "field_path": path})
             )
         block_updates[name] = block.model_copy(update={"claim_ids": canonical_ids})
     if len(claims_to_normalize) > 12:
@@ -224,9 +305,7 @@ def normalize_analysis_item(
             body = claim.text.removeprefix(prefix)
             while ANCHOR_RE.search(body):
                 body = ANCHOR_RE.sub(
-                    lambda match: "相关指标"
-                    if match.group(0)[0].isdigit()
-                    else "相关版本",
+                    lambda match: "相关指标" if match.group(0)[0].isdigit() else "相关版本",
                     body,
                 )
             claim_updates["text"] = prefix + body
@@ -444,14 +523,18 @@ def _first_person_allowed(
     claims: dict[str, AnalysisClaim],
     memories: dict[str, EditorialMemory],
 ) -> bool:
-    memory_ids = {
-        memory_id
-        for claim_id in block.claim_ids
-        for memory_id in claims[claim_id].experience_memory_ids
-    }
-    return bool(memory_ids) and all(
-        memory_id in memories and memories[memory_id].usage == "first_person_allowed"
-        for memory_id in memory_ids
+    try:
+        referenced = [claims[claim_id] for claim_id in block.claim_ids]
+    except KeyError as error:
+        raise ValueError(f"unknown claim id: {error.args[0]}") from error
+    return bool(referenced) and all(
+        claim.claim_type == "experience_fact"
+        and bool(claim.experience_memory_ids)
+        and all(
+            memory_id in memories and memories[memory_id].usage == "first_person_allowed"
+            for memory_id in claim.experience_memory_ids
+        )
+        for claim in referenced
     )
 
 

--- a/tests/test_budget_staging.py
+++ b/tests/test_budget_staging.py
@@ -172,7 +172,8 @@ def test_persona_budget_can_retry_configured_analysts_after_charged_failures() -
 
     assert ledger.reserved_requests == 4
     assert ledger.reserved_output_tokens == 192_000
-    assert ledger.remaining_cost() == pytest.approx(7.864466)
+    expected = config.persona.budget.cost_cny_limit - 6.645534 - 0.09 - 1.4
+    assert ledger.remaining_cost() == pytest.approx(expected)
 
 
 def test_stage_totals_are_reported_separately(tmp_path: Path) -> None:

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -115,6 +115,43 @@ async def test_provider_sdk_retries_are_disabled() -> None:
             await model.provider.client.close()
 
 
+async def test_generate_returns_the_model_replaced_by_semantic_validator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    gateway = ModelGateway(load_config().models, Secrets())
+
+    async def respond(messages: object, info: AgentInfo) -> ModelResponse:
+        del messages
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    info.output_tools[0].name,
+                    {
+                        "event_id": "event-1",
+                        "selected": True,
+                        "category": "行业动态",
+                        "relevance": 90,
+                        "confidence": 0.9,
+                        "reason": "模型原始判断",
+                        "evidence_ids": ["event-1-1"],
+                    },
+                )
+            ]
+        )
+
+    monkeypatch.setattr(gateway, "_build_model", lambda endpoint: FunctionModel(respond))
+
+    result = await gateway.generate(
+        "judge",
+        JudgeDecision,
+        "instructions",
+        "prompt",
+        validator=lambda value: value.model_copy(update={"reason": "规范化判断"}),
+    )
+
+    assert result.reason == "规范化判断"
+
+
 def test_fallback_audit_preserves_requested_model() -> None:
     gateway = ModelGateway(load_config().models, Secrets(), clock=lambda: 1.0)
     role = gateway.config.roles["judge"]

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -26,8 +26,10 @@ from ai_daily.persona_models import (
     Critique,
     CritiqueFinding,
     EditionDraft,
+    EditorialMemory,
     FinalizerOutput,
     FinalizerResolution,
+    MemoryKind,
     OperationReceipt,
     PersonaContext,
     PersonaEdition,
@@ -43,6 +45,7 @@ from ai_daily.persona_pipeline import (
     PersonaPipeline,
     _analyst_event_row,
     _json_prompt,
+    _memory_context_sha256,
     _normalize_plan,
     _validate_critique,
     _validate_finalizer_changes,
@@ -57,6 +60,7 @@ from ai_daily.persona_snapshot import (
 from ai_daily.persona_verifier import (
     VerificationScope,
     normalize_analysis_item,
+    normalize_edition_draft,
     verify_analysis_item,
     verify_edition,
 )
@@ -644,6 +648,228 @@ def test_verifier_accepts_exact_claim_assembly_and_rejects_first_person(
         verify_edition(bad, snapshot, _scope(), config)
 
 
+def test_editor_normalization_removes_unapproved_first_person_and_rebuilds_blocks(
+    tmp_path: Path,
+) -> None:
+    config = load_config(Path("config")).persona
+    assert config is not None
+    layout = SiteLayout(tmp_path)
+    layout.ensure()
+    snapshot = _snapshot(layout)
+    draft = _edition_draft(snapshot.publication_marker)
+    old_claim = draft.claims[2]
+    first_person_text = "判断：" + "我们需要把自我感觉换成可验证的产品证据。" * 12
+    first_person = old_claim.model_copy(update={"text": first_person_text})
+    candidate = draft.model_copy(
+        update={
+            "claims": [draft.claims[0], draft.claims[1], first_person, draft.claims[3]],
+            "thesis_block": draft.thesis_block.model_copy(update={"text": first_person.text}),
+        }
+    )
+
+    normalized = normalize_edition_draft(candidate, _scope())
+
+    expected = "判断：" + "产品团队需要把自我感觉换成可验证的产品证据。" * 12
+    assert normalized.claims[2].text == expected
+    assert normalized.thesis_block.text == normalized.claims[2].text
+    assert verify_edition(normalized, snapshot, _scope(), config).hash_is_valid()
+
+    unknown = draft.model_copy(
+        update={
+            "title_block": draft.title_block.model_copy(update={"claim_ids": ["claim-missing"]})
+        }
+    )
+    with pytest.raises(ValueError, match="unknown claim id"):
+        normalize_edition_draft(unknown, _scope())
+
+    extra_claim = draft.claims[0].model_copy(update={"claim_id": "claim-unreferenced"})
+    extra = draft.model_copy(update={"claims": [*draft.claims, extra_claim]})
+    with pytest.raises(ValueError, match="unreferenced edition claim"):
+        normalize_edition_draft(extra, _scope())
+
+
+def test_persona_cli_accepts_a_resume_run_path() -> None:
+    args = cli.build_parser().parse_args(
+        [
+            "persona-run",
+            "--date",
+            TARGET.isoformat(),
+            "--mode",
+            "site",
+            "--resume-run",
+            "/tmp/persona-run",
+        ]
+    )
+
+    assert args.resume_run == Path("/tmp/persona-run")
+
+
+@pytest.mark.parametrize(
+    ("voice", "neutral"),
+    [
+        ("我们应该", "产品团队应该"),
+        ("咱们应该", "产品团队应该"),
+    ],
+)
+def test_editor_normalization_covers_every_unapproved_voice_token(
+    voice: str,
+    neutral: str,
+) -> None:
+    draft = _edition_draft("a" * 64)
+    claim = draft.claims[0].model_copy(update={"text": f"判断：{voice}继续验证。"})
+    candidate = draft.model_copy(
+        update={
+            "claims": [claim, *draft.claims[1:]],
+            "title_block": draft.title_block.model_copy(update={"text": claim.text}),
+        }
+    )
+
+    normalized = normalize_edition_draft(candidate, _scope())
+
+    assert normalized.title_block.text == f"判断：{neutral}继续验证。"
+
+
+@pytest.mark.parametrize("voice", ["我的判断", "本人建议", "我亲自测试过"])
+def test_editor_does_not_rewrite_unsupported_personal_experience(
+    voice: str,
+    tmp_path: Path,
+) -> None:
+    config = load_config(Path("config")).persona
+    assert config is not None
+    layout = SiteLayout(tmp_path)
+    layout.ensure()
+    snapshot = _snapshot(layout)
+    draft = _edition_draft(snapshot.publication_marker)
+    claim = draft.claims[0].model_copy(update={"text": f"判断：{voice}。"})
+    candidate = draft.model_copy(
+        update={
+            "claims": [claim, *draft.claims[1:]],
+            "title_block": draft.title_block.model_copy(update={"text": claim.text}),
+        }
+    )
+
+    normalized = normalize_edition_draft(candidate, _scope())
+
+    assert normalized.title_block.text == claim.text
+    with pytest.raises(ValueError, match="first-person"):
+        verify_edition(normalized, snapshot, _scope(), config)
+
+
+@pytest.mark.parametrize("voice", ["帮助我更快完成工作", "有利于我判断", "助我验证"])
+def test_verifier_rejects_first_person_after_common_prefixes(
+    voice: str,
+    tmp_path: Path,
+) -> None:
+    config = load_config(Path("config")).persona
+    assert config is not None
+    layout = SiteLayout(tmp_path)
+    layout.ensure()
+    snapshot = _snapshot(layout)
+    draft = _edition_draft(snapshot.publication_marker)
+    claim = draft.claims[0].model_copy(update={"text": f"判断：{voice}。"})
+    candidate = draft.model_copy(
+        update={
+            "claims": [claim, *draft.claims[1:]],
+            "title_block": draft.title_block.model_copy(update={"text": claim.text}),
+        }
+    )
+
+    normalized = normalize_edition_draft(candidate, _scope())
+
+    with pytest.raises(ValueError, match="first-person"):
+        verify_edition(normalized, snapshot, _scope(), config)
+
+
+@pytest.mark.parametrize("phrase", ["忘我投入", "无我协作", "自我检查"])
+def test_editor_preserves_non_pronoun_words_containing_wo(phrase: str) -> None:
+    draft = _edition_draft("a" * 64)
+    claim = draft.claims[0].model_copy(update={"text": f"判断：团队保持{phrase}。"})
+    candidate = draft.model_copy(
+        update={
+            "claims": [claim, *draft.claims[1:]],
+            "title_block": draft.title_block.model_copy(update={"text": claim.text}),
+        }
+    )
+
+    assert normalize_edition_draft(candidate, _scope()).title_block.text == claim.text
+
+
+def test_editor_preserves_voice_approved_by_public_memory(tmp_path: Path) -> None:
+    config = load_config(Path("config")).persona
+    assert config is not None
+    layout = SiteLayout(tmp_path)
+    layout.ensure()
+    snapshot = _snapshot(layout)
+    memory = EditorialMemory(
+        memory_id="mem-first-person",
+        kind=MemoryKind.EXPERIENCE,
+        statement="我会先验证用户是否真的得到价值。",
+        topics=["产品"],
+        valid_from=TARGET,
+        status="approved",
+        confidence="explicit",
+        usage="first_person_allowed",
+        source_path="public.md",
+        source_artifact_id="a" * 64,
+        source_excerpt="我会先验证用户是否真的得到价值。",
+        publicity="public",
+    )
+    draft = _edition_draft(snapshot.publication_marker)
+    claim = draft.claims[0].model_copy(
+        update={
+            "text": "我会先验证用户是否真的得到价值。",
+            "claim_type": "experience_fact",
+            "current_evidence_ids": [],
+            "experience_memory_ids": [memory.memory_id],
+            "quotes": [
+                ClaimQuote(
+                    source_kind="experience_memory",
+                    source_id=memory.memory_id,
+                    quote=memory.source_excerpt,
+                )
+            ],
+        }
+    )
+    candidate = draft.model_copy(
+        update={
+            "claims": [claim, *draft.claims[1:]],
+            "title_block": draft.title_block.model_copy(update={"text": claim.text}),
+        }
+    )
+    scope = _scope()
+    scope = VerificationScope(
+        memories={memory.memory_id: memory},
+        baseline_evidence=scope.baseline_evidence,
+        current_ids_by_event=scope.current_ids_by_event,
+        baseline_ids_by_event=scope.baseline_ids_by_event,
+        memory_ids_by_event={"event-0": {memory.memory_id}},
+    )
+
+    normalized = normalize_edition_draft(candidate, scope)
+
+    assert normalized.title_block.text == claim.text
+    assert verify_edition(normalized, snapshot, scope, config).hash_is_valid()
+
+    unsupported = _claim(
+        "claim-unsupported-personal",
+        "title_block",
+        "判断：我亲自做过很多成功产品。",
+    )
+    mixed = candidate.model_copy(
+        update={
+            "claims": [claim, unsupported, *draft.claims[1:]],
+            "title_block": draft.title_block.model_copy(
+                update={
+                    "text": claim.text + unsupported.text,
+                    "claim_ids": [claim.claim_id, unsupported.claim_id],
+                }
+            ),
+        }
+    )
+    with pytest.raises(ValueError, match="first-person"):
+        verify_edition(normalize_edition_draft(mixed, scope), snapshot, scope, config)
+
+
 def test_verifier_rejects_fabricated_provenance_and_source_links(tmp_path: Path) -> None:
     config = load_config(Path("config")).persona
     assert config is not None
@@ -785,9 +1011,7 @@ def test_analysis_normalization_gives_reused_claims_stable_unique_ids(tmp_path: 
     verify_analysis_item(normalized, snapshot, _scope())
     assert normalized.headline_block.claim_ids != normalized.importance_block.claim_ids
     assert normalized == repeated
-    assert len(normalized.claims) == len(
-        {claim.claim_id for claim in normalized.claims}
-    )
+    assert len(normalized.claims) == len({claim.claim_id for claim in normalized.claims})
 
 
 def test_verifier_rejects_fabricated_fact_labeled_as_inference(tmp_path: Path) -> None:
@@ -1791,7 +2015,7 @@ class _FakeGateway:
             raise AssertionError(role)
         validator = kwargs.get("validator")
         if validator:
-            validator(value)
+            value = validator(value) or value
         return cast(Any, value)
 
 
@@ -1843,8 +2067,20 @@ class _StandardGateway:
             raise AssertionError(role)
         validator = kwargs.get("validator")
         if validator:
-            validator(value)
+            value = validator(value) or value
         return cast(Any, value)
+
+
+class _ResumeGateway(_StandardGateway):
+    def __init__(self, draft: EditionDraft) -> None:
+        super().__init__(draft)
+        self.roles: list[str] = []
+
+    async def generate(self, role: str, output_type: Any, *args: Any, **kwargs: Any) -> Any:
+        self.roles.append(role)
+        if role in {"persona_planner", "persona_baseline", "persona_analyst"}:
+            raise AssertionError(f"resume unexpectedly invoked {role}")
+        return await super().generate(role, output_type, *args, **kwargs)
 
 
 class _FinalizerGateway:
@@ -1902,7 +2138,7 @@ class _FinalizerGateway:
             raise AssertionError(role)
         validator = kwargs.get("validator")
         if validator:
-            validator(value)
+            value = validator(value) or value
         return cast(Any, value)
 
 
@@ -1913,6 +2149,13 @@ async def test_persona_pipeline_runs_end_to_end_without_provider(tmp_path: Path)
     snapshot = _snapshot(layout)
     activate_upstream_snapshot(layout, TARGET, snapshot.publication_marker)
     draft = _edition_draft(snapshot.publication_marker)
+    title_claim = draft.claims[0].model_copy(update={"text": "判断：我们今天没有必须追的大更新"})
+    draft = draft.model_copy(
+        update={
+            "claims": [title_claim, *draft.claims[1:]],
+            "title_block": draft.title_block.model_copy(update={"text": title_claim.text}),
+        }
+    )
     gateway = _FakeGateway(draft)
     pipeline = PersonaPipeline(
         load_config(Path("config")),
@@ -1930,6 +2173,7 @@ async def test_persona_pipeline_runs_end_to_end_without_provider(tmp_path: Path)
         layout.persona_edition_path(TARGET).read_text(encoding="utf-8")
     )
     assert persisted.hash_is_valid()
+    assert persisted.title_block.text == "判断：产品团队今天没有必须追的大更新"
 
 
 @pytest.mark.asyncio
@@ -2015,6 +2259,175 @@ async def test_standard_pipeline_analyzes_multiple_events_concurrently(
     )
     assert [item.event_id for item in persisted.items] == ["event-0", "event-1"]
     assert persisted.hash_is_valid()
+
+
+async def _resume_source(
+    tmp_path: Path,
+) -> tuple[SiteLayout, UpstreamSnapshot, Any, EditionDraft, Path]:
+    layout = SiteLayout(tmp_path / "site")
+    layout.ensure()
+    events = [factories.event(0), factories.event(1)]
+    unsigned = UpstreamSnapshot(
+        target_date=TARGET,
+        publication_level=PublicationLevel.L0,
+        publication_marker="d" * 64,
+        events=events,
+        evidence_bundles=[evidence_bundle(event) for event in events],
+        decisions=[factories.judge_decision(index) for index in range(2)],
+        editorial_plan=None,
+        snapshot_sha256="0" * 64,
+    )
+    snapshot = unsigned.model_copy(
+        update={"snapshot_sha256": sha256_payload(unsigned.canonical_payload())}
+    )
+    write_artifact(layout.upstream_object_path(snapshot.publication_marker), snapshot)
+    activate_upstream_snapshot(layout, TARGET, snapshot.publication_marker)
+    config = load_config(Path("config"))
+    draft = _standard_draft(snapshot.publication_marker)
+    source_pipeline = PersonaPipeline(
+        config,
+        Secrets(),
+        layout,
+        Path.cwd(),
+        TARGET,
+        gateway=cast(Any, _StandardGateway(draft)),
+    )
+    first = await source_pipeline.run(TARGET)
+    assert first.editorial_state == "ready", first.reason
+    source_run = next((layout.persona_runs / TARGET.isoformat()).iterdir())
+    layout.persona_edition_path(TARGET).unlink()
+    return layout, snapshot, config, draft, source_run
+
+
+def _resumed_pipeline(
+    layout: SiteLayout,
+    config: Any,
+    draft: EditionDraft,
+    gateway: _ResumeGateway,
+) -> PersonaPipeline:
+    return PersonaPipeline(
+        config,
+        Secrets(),
+        layout,
+        Path.cwd(),
+        TARGET,
+        gateway=cast(Any, gateway),
+    )
+
+
+async def _assert_resume_held(
+    fixture: tuple[SiteLayout, UpstreamSnapshot, Any, EditionDraft, Path],
+    source: Path,
+    reason: str,
+) -> None:
+    layout, _, config, draft, _ = fixture
+    gateway = _ResumeGateway(draft)
+    result = await _resumed_pipeline(layout, config, draft, gateway).run(TARGET, source)
+    assert result.editorial_state == "held"
+    assert reason in str(result.reason)
+    assert gateway.roles == []
+    assert not layout.persona_edition_path(TARGET).exists()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_resumes_verified_analyses_without_reinvoking_earlier_stages(
+    tmp_path: Path,
+) -> None:
+    fixture = await _resume_source(tmp_path)
+    layout, _, config, draft, source_run = fixture
+    gateway = _ResumeGateway(draft)
+    resumed_pipeline = _resumed_pipeline(layout, config, draft, gateway)
+
+    resumed = await resumed_pipeline.run(TARGET, source_run)
+
+    assert resumed.editorial_state == "ready", resumed.reason
+    assert gateway.roles == ["persona_edition_editor", "persona_critic"]
+    run_dirs = sorted((layout.persona_runs / TARGET.isoformat()).iterdir())
+    assert any((run_dir / "resume.json").exists() for run_dir in run_dirs)
+
+
+@pytest.mark.asyncio
+async def test_resumed_analyses_reject_missing_reordered_or_expanded_scope(
+    tmp_path: Path,
+) -> None:
+    layout, snapshot, config, draft, source_run = await _resume_source(tmp_path)
+    pipeline = _resumed_pipeline(layout, config, draft, _ResumeGateway(draft))
+    context = PersonaContext.model_validate_json(
+        (source_run / "context.json").read_text(encoding="utf-8")
+    )
+    memories, _ = pipeline._memory_context(snapshot.events, TARGET)
+    assert context.memory_context_sha256 == _memory_context_sha256(
+        context.retrieved_memories, memories
+    )
+    plan, analyses, scope = pipeline._resume_analysis(source_run, snapshot, context, memories)
+    with pytest.raises(ValueError, match="cover every"):
+        pipeline._verify_resumed_analyses(plan, analyses[:-1], snapshot, scope)
+    with pytest.raises(ValueError, match="order or grade"):
+        pipeline._verify_resumed_analyses(plan, list(reversed(analyses)), snapshot, scope)
+    extra_evidence = analyses[0].model_copy(
+        update={"evidence_ids": [*analyses[0].evidence_ids, "outside-plan"]}
+    )
+    with pytest.raises(ValueError, match="outside the plan"):
+        pipeline._verify_resumed_analyses(plan, [extra_evidence, analyses[1]], snapshot, scope)
+    extra_memory = analyses[0].model_copy(update={"memory_ids": ["mem-outside"]})
+    with pytest.raises(ValueError, match="memory outside"):
+        pipeline._verify_resumed_analyses(plan, [extra_memory, analyses[1]], snapshot, scope)
+
+    memory_id = context.retrieved_memories[0].memory_id
+    changed_memories = {
+        **memories,
+        memory_id: memories[memory_id].model_copy(update={"statement": "内容已经变化。"}),
+    }
+    changed_context = context.model_copy(
+        update={
+            "memory_context_sha256": _memory_context_sha256(
+                context.retrieved_memories, changed_memories
+            )
+        }
+    )
+    with pytest.raises(ValueError, match="context no longer matches"):
+        pipeline._resume_analysis(source_run, snapshot, changed_context, changed_memories)
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_paths_outside_target_date_and_context_drift(
+    tmp_path: Path,
+) -> None:
+    fixture = await _resume_source(tmp_path)
+    _, _, _, _, source_run = fixture
+    outside = tmp_path / "outside-run"
+    outside.mkdir()
+    await _assert_resume_held(fixture, outside, "target date")
+
+    context = PersonaContext.model_validate_json(
+        (source_run / "context.json").read_text(encoding="utf-8")
+    )
+    legacy = context.model_copy(update={"memory_context_sha256": None})
+    (source_run / "context.json").write_text(legacy.model_dump_json(), encoding="utf-8")
+    await _assert_resume_held(fixture, source_run, "memory-content attestation")
+
+    mismatched = context.model_copy(update={"upstream_marker": "e" * 64})
+    (source_run / "context.json").write_text(mismatched.model_dump_json(), encoding="utf-8")
+    await _assert_resume_held(fixture, source_run, "context no longer matches")
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_baselines_without_persisted_evidence(tmp_path: Path) -> None:
+    fixture = await _resume_source(tmp_path)
+    _, _, _, _, source_run = fixture
+    write_artifact(
+        source_run / "baselines.json",
+        {
+            "event-0": {
+                "event_id": "event-0",
+                "matched_event_id": "historical-event",
+                "baseline_evidence_ids": ["historical-evidence"],
+                "confidence": 0.9,
+                "reasoning": "用于验证恢复拒绝没有证据映射的历史基线。",
+            }
+        },
+    )
+    await _assert_resume_held(fixture, source_run, "without evidence artifacts")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add evidence-attested tail resume for failed persona editorial runs
- normalize collective voice while rejecting unsupported first-person claims
- tighten memory and block trust boundaries, plus raise the daily tail budget cap

## Verification
- `uv run ruff format --check` on changed Python files
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest -q`
- `git diff --check`

## Operational scope
This enables resuming the verified 2026-08-27 production analyses without repeating planner or analyst model calls. WeChat remains draft-only.