### PR TITLE
Normalize persona interpretation labels

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -9,7 +9,7 @@ memory_limit: 16
 # retry while preserving every selected analysis.
 analyst_concurrency: 2
 # Minimum per-call reservation. The gateway raises this to the prompt/token
-# price ceiling (about ¥0.6-1.0 for current calls), while the ¥18 cap is absolute.
+# price ceiling (about ¥0.6-1.0 for current calls), while the ¥20 cap is absolute.
 max_call_cost_cny: 0.25
 baseline_window_days: 90
 evidence_retention_days: 120
@@ -20,7 +20,7 @@ no_major_max_chars: 600
 publish_mode: draft_only
 ai_disclosure: 本文由 AI 参与资料整理和初稿生成，并经过证据约束与自动审稿。
 budget:
-  # These are runaway backstops, not normal-run quotas. The ¥18 ceiling remains
+  # These are runaway backstops, not normal-run quotas. The ¥20 ceiling remains
   # binding before current DeepSeek pricing can consume these token allowances.
   # Same-day recovery may accumulate schema retries that cost little or nothing;
   # money remains the binding safety control.
@@ -32,4 +32,4 @@ budget:
   output_token_limit: 2100000
   # Fresh successful editions are expected to stay around ¥1-2. The higher hard
   # stop preserves same-day recovery after charged provider or validation failures.
-  cost_cny_limit: 18.0
+  cost_cny_limit: 20.0

--- a/src/ai_daily/persona_verifier.py
+++ b/src/ai_daily/persona_verifier.py
@@ -152,7 +152,7 @@ def normalize_edition_draft(
     draft: EditionDraft,
     scope: VerificationScope,
 ) -> EditionDraft:
-    """Remove unapproved author voice from interpretive claims, then rebuild blocks."""
+    """Normalize mechanical labels and collective voice, then rebuild blocks."""
     claims = _claim_map(draft.claims)
     normalized: dict[str, AnalysisClaim] = {}
     block_updates: dict[str, PublicTextBlock] = {}
@@ -165,6 +165,9 @@ def normalize_edition_draft(
             text = claim.text
             if claim.claim_type in INTERPRETIVE_PREFIX:
                 text = _neutralize_collective_voice(text)
+                prefix = INTERPRETIVE_PREFIX[claim.claim_type]
+                if not text.startswith(prefix):
+                    text = prefix + text
             normalized[claim_id] = claim.model_copy(update={"text": text})
         block_updates[path] = block.model_copy(
             update={"text": "".join(normalized[item].text for item in block.claim_ids)}

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -729,6 +729,34 @@ def test_editor_normalization_covers_every_unapproved_voice_token(
     assert normalized.title_block.text == f"判断：{neutral}继续验证。"
 
 
+@pytest.mark.parametrize(
+    ("claim_type", "text", "expected"),
+    [
+        ("inference", "这项变化值得跟进。", "判断：这项变化值得跟进。"),
+        ("recommendation", "先做小流量验证。", "建议：先做小流量验证。"),
+        ("uncertainty", "长期效果尚待观察。", "不确定性：长期效果尚待观察。"),
+    ],
+)
+def test_editor_normalization_adds_missing_interpretive_label(
+    claim_type: str,
+    text: str,
+    expected: str,
+) -> None:
+    draft = _edition_draft("a" * 64)
+    claim = draft.claims[0].model_copy(update={"claim_type": claim_type, "text": text})
+    candidate = draft.model_copy(
+        update={
+            "claims": [claim, *draft.claims[1:]],
+            "title_block": draft.title_block.model_copy(update={"text": claim.text}),
+        }
+    )
+
+    normalized = normalize_edition_draft(candidate, _scope())
+
+    assert normalized.title_block.text == expected
+    assert normalized.claims[0].text == expected
+
+
 @pytest.mark.parametrize("voice", ["我的判断", "本人建议", "我亲自测试过"])
 def test_editor_does_not_rewrite_unsupported_personal_experience(
     voice: str,


### PR DESCRIPTION
## Summary
- deterministically add missing interpretation labels from the declared claim type
- preserve all evidence, source, first-person, and block verification
- leave recovery headroom by setting the same-day persona hard cost cap to ¥20

## Production evidence
The verified 2026-08-27 tail was held after two editor attempts because an `uncertainty` claim omitted its required `不确定性：` label. No edition, site update, or WeChat draft was created.

## Verification
- targeted persona and budget tests
- `uv run ruff format --check` on changed Python files
- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest -q`
- `git diff --check`