### PR TITLE
Neutralize generic reader voice safely

### DIFF
--- a/src/ai_daily/persona_verifier.py
+++ b/src/ai_daily/persona_verifier.py
@@ -24,6 +24,31 @@ COLLECTIVE_VOICE_REPLACEMENTS = {
     "我们": "产品团队",
     "咱们": "产品团队",
 }
+GENERIC_READER_VOICE_REPLACEMENTS = {
+    "在我看来，": "",
+    "在我看来": "",
+    "我的判断是": "",
+    "我的建议是": "",
+    "我为什么认为": "为什么",
+    "我认为": "",
+    "我觉得": "",
+    "我判断": "",
+    "我建议": "",
+    "帮助我": "帮助用户",
+    "帮我": "帮助用户",
+    "助我": "帮助用户",
+    "替我": "替用户",
+    "让我": "让用户",
+    "给我": "给用户",
+    "对我": "对用户",
+    "于我": "于用户",
+}
+GENERIC_READER_VOICE_RE = re.compile(
+    "|".join(
+        re.escape(value)
+        for value in sorted(GENERIC_READER_VOICE_REPLACEMENTS, key=len, reverse=True)
+    )
+)
 COLLECTIVE_VOICE_PATTERN = "|".join(
     re.escape(value) for value in sorted(COLLECTIVE_VOICE_REPLACEMENTS, key=len, reverse=True)
 )
@@ -90,7 +115,10 @@ def verify_edition(
         if _contains_first_person(block.text) and not _first_person_allowed(
             block, claims, scope.memories
         ):
-            raise ValueError(f"unapproved first-person voice at {path}")
+            raise ValueError(
+                f"unapproved first-person voice at {path}; remove 我/我的/本人/"
+                "我们/咱们 unless every claim is an approved experience_fact"
+            )
     _verify_claim_inventory(blocks, claims)
     _verify_item_sources(draft, claims, current_by_event, scope)
     for claim in claims.values():
@@ -164,7 +192,7 @@ def normalize_edition_draft(
                 raise ValueError(f"unknown claim id at {path}: {claim_id}") from error
             text = claim.text
             if claim.claim_type in INTERPRETIVE_PREFIX:
-                text = _neutralize_collective_voice(text)
+                text = _neutralize_generic_voice(_neutralize_collective_voice(text))
                 prefix = INTERPRETIVE_PREFIX[claim.claim_type]
                 if not text.startswith(prefix):
                     text = prefix + text
@@ -178,6 +206,12 @@ def normalize_edition_draft(
 def _neutralize_collective_voice(text: str) -> str:
     return COLLECTIVE_VOICE_RE.sub(
         lambda match: COLLECTIVE_VOICE_REPLACEMENTS[match.group(0)], text
+    )
+
+
+def _neutralize_generic_voice(text: str) -> str:
+    return GENERIC_READER_VOICE_RE.sub(
+        lambda match: GENERIC_READER_VOICE_REPLACEMENTS[match.group(0)], text
     )
 
 

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -757,7 +757,7 @@ def test_editor_normalization_adds_missing_interpretive_label(
     assert normalized.claims[0].text == expected
 
 
-@pytest.mark.parametrize("voice", ["我的判断", "本人建议", "我亲自测试过"])
+@pytest.mark.parametrize("voice", ["我亲自测试过", "我用过这个产品", "本人亲测有效"])
 def test_editor_does_not_rewrite_unsupported_personal_experience(
     voice: str,
     tmp_path: Path,
@@ -783,6 +783,30 @@ def test_editor_does_not_rewrite_unsupported_personal_experience(
         verify_edition(normalized, snapshot, _scope(), config)
 
 
+@pytest.mark.parametrize(
+    ("voice", "neutral"),
+    [
+        ("在我看来，需要继续验证", "需要继续验证"),
+        ("我认为需要继续验证", "需要继续验证"),
+        ("这项工具帮助我更快完成工作", "这项工具帮助用户更快完成工作"),
+        ("这项工具有利于我完成工作", "这项工具有利于用户完成工作"),
+    ],
+)
+def test_editor_neutralizes_generic_reader_voice(voice: str, neutral: str) -> None:
+    draft = _edition_draft("a" * 64)
+    claim = draft.claims[0].model_copy(update={"text": f"判断：{voice}。"})
+    candidate = draft.model_copy(
+        update={
+            "claims": [claim, *draft.claims[1:]],
+            "title_block": draft.title_block.model_copy(update={"text": claim.text}),
+        }
+    )
+
+    normalized = normalize_edition_draft(candidate, _scope())
+
+    assert normalized.title_block.text == f"判断：{neutral}。"
+
+
 @pytest.mark.parametrize("voice", ["帮助我更快完成工作", "有利于我判断", "助我验证"])
 def test_verifier_rejects_first_person_after_common_prefixes(
     voice: str,
@@ -802,10 +826,13 @@ def test_verifier_rejects_first_person_after_common_prefixes(
         }
     )
 
+    with pytest.raises(ValueError, match="first-person"):
+        verify_edition(candidate, snapshot, _scope(), config)
+
     normalized = normalize_edition_draft(candidate, _scope())
 
-    with pytest.raises(ValueError, match="first-person"):
-        verify_edition(normalized, snapshot, _scope(), config)
+    assert "我" not in normalized.title_block.text
+    verify_edition(normalized, snapshot, _scope(), config)
 
 
 @pytest.mark.parametrize("phrase", ["忘我投入", "无我协作", "自我检查"])


### PR DESCRIPTION
## Summary
- neutralize a bounded set of generic reader-view phrases such as `帮助我` and `在我看来`
- keep unsupported personal-experience claims unchanged so strict verification still rejects them
- return actionable retry feedback naming forbidden first-person tokens

## Production evidence
The 2026-08-27 editor tail passed label normalization but was held because both model outputs retained first-person voice in the first headline. No edition, site update, or WeChat draft was created.

## Verification
- raw first-person bypass regression remains rejected
- generic reader voice normalizes and verifies
- unsupported personal experience remains rejected
- Ruff, mypy, full pytest suite, and diff check pass