### PR TITLE
Preserve persona recovery token headroom

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -25,11 +25,11 @@ budget:
   # Same-day recovery may accumulate schema retries that cost little or nothing;
   # money remains the binding safety control.
   request_limit: 140
-  input_token_limit: 1500000
+  input_token_limit: 2000000
   # The persona gateway reserves the worst case before a call. Two concurrent
   # 48k-output calls with one schema retry can reserve 192k even though actual
   # usage is much lower. Keep tokens non-binding and let the ¥18 ceiling stop spend.
-  output_token_limit: 2100000
+  output_token_limit: 2500000
   # Fresh successful editions are expected to stay around ¥1-2. The higher hard
   # stop preserves same-day recovery after charged provider or validation failures.
   cost_cny_limit: 20.0


### PR DESCRIPTION
## Summary
- raise only the persona input/output token backstops to 2.0M/2.5M
- keep the ¥20 cost ceiling and 140-request ceiling as the binding safeguards

## Production evidence
The voice-normalization retry made zero model requests because accumulated same-day failures left less than one pessimistic editor reservation under the old token caps. Current spend remains ¥17.05.

## Verification
- persona and budget staging tests pass
- production config loads with the exact new limits
- diff check passes