### PR TITLE
Route persona edition to structured model

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -81,6 +81,24 @@ roles:
     <<: *persona_editor
   persona_edition_editor:
     <<: *persona_editor
+    primary:
+      provider: openai
+      model: gpt-5.6-terra
+      timeout_seconds: 180
+      # The edition JSON is much smaller than planner reasoning output, but five
+      # fully traced items can exceed the shared 8k fallback ceiling.
+      max_output_tokens: 12000
+      temperature: 1.0
+      input_cost_cny_per_million: 12.0
+      output_cost_cny_per_million: 96.0
+    fallback:
+      provider: deepseek
+      model: deepseek-v4-pro
+      timeout_seconds: 180
+      max_output_tokens: 48000
+      temperature: 0.2
+      input_cost_cny_per_million: 3.13
+      output_cost_cny_per_million: 6.26
   persona_critic:
     <<: *persona_editor
   persona_finalizer:

--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -9,7 +9,7 @@ memory_limit: 16
 # retry while preserving every selected analysis.
 analyst_concurrency: 2
 # Minimum per-call reservation. The gateway raises this to the prompt/token
-# price ceiling (about ¥0.6-1.0 for current calls), while the ¥20 cap is absolute.
+# price ceiling (about ¥0.6-1.0 for current calls), while the ¥22 cap is absolute.
 max_call_cost_cny: 0.25
 baseline_window_days: 90
 evidence_retention_days: 120
@@ -20,16 +20,16 @@ no_major_max_chars: 600
 publish_mode: draft_only
 ai_disclosure: 本文由 AI 参与资料整理和初稿生成，并经过证据约束与自动审稿。
 budget:
-  # These are runaway backstops, not normal-run quotas. The ¥20 ceiling remains
+  # These are runaway backstops, not normal-run quotas. The ¥22 ceiling remains
   # binding before current DeepSeek pricing can consume these token allowances.
   # Same-day recovery may accumulate schema retries that cost little or nothing;
   # money remains the binding safety control.
-  request_limit: 140
+  request_limit: 150
   input_token_limit: 2000000
   # The persona gateway reserves the worst case before a call. Two concurrent
   # 48k-output calls with one schema retry can reserve 192k even though actual
-  # usage is much lower. Keep tokens non-binding and let the ¥18 ceiling stop spend.
+  # usage is much lower. Keep tokens non-binding and let the ¥22 ceiling stop spend.
   output_token_limit: 2500000
   # Fresh successful editions are expected to stay around ¥1-2. The higher hard
   # stop preserves same-day recovery after charged provider or validation failures.
-  cost_cny_limit: 20.0
+  cost_cny_limit: 22.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,7 +68,7 @@ def test_persona_recovery_request_budget_stays_within_schema_ceiling() -> None:
     config = load_config(Path("config"))
 
     assert config.persona is not None
-    assert config.persona.budget.request_limit == 140
+    assert config.persona.budget.request_limit == 150
 
 
 def test_huggingface_model_source_requires_namespace() -> None:


### PR DESCRIPTION
## Summary
- route only the persona edition editor to `gpt-5.6-terra` with a 12k structured-output ceiling
- retain DeepSeek as the editor fallback and for planning, analysis, critics, and finalization
- raise same-day recovery hard stops to ¥22 and 150 requests after the accumulated failed canary attempts

## Production evidence
The latest DeepSeek editor run had one zero-cost API failure, then exhausted structured-output retries after 109k input and 77k output tokens. No edition, site update, or WeChat draft was created.

## Verification
- full pytest suite passes
- Ruff and mypy pass
- config loads with the exact model and recovery limits
- diff check passes