### PR TITLE
Keep confirmed persona changes factual

### DIFF
--- a/src/ai_daily/persona_verifier.py
+++ b/src/ai_daily/persona_verifier.py
@@ -188,8 +188,21 @@ def normalize_edition_draft(
     claims = _claim_map(draft.claims)
     normalized: dict[str, AnalysisClaim] = {}
     block_updates: dict[str, PublicTextBlock] = {}
+    dropped_claim_ids: set[str] = set()
     for path, block in _blocks(draft):
-        for claim_id in block.claim_ids:
+        claim_ids = block.claim_ids
+        unknown_claim_ids = set(claim_ids) - set(claims)
+        if unknown_claim_ids:
+            unknown = sorted(unknown_claim_ids)[0]
+            raise ValueError(f"unknown claim id at {path}: {unknown}")
+        if path.endswith(".confirmed_change_block"):
+            claim_ids = [
+                claim_id for claim_id in claim_ids if claims[claim_id].claim_type == "current_fact"
+            ]
+            if not claim_ids:
+                raise ValueError(f"confirmed change has no current facts at {path}")
+            dropped_claim_ids.update(set(block.claim_ids) - set(claim_ids))
+        for claim_id in claim_ids:
             try:
                 claim = claims[claim_id]
             except KeyError as error:
@@ -202,9 +215,16 @@ def normalize_edition_draft(
                     text = prefix + text
             normalized[claim_id] = claim.model_copy(update={"text": text})
         block_updates[path] = block.model_copy(
-            update={"text": "".join(normalized[item].text for item in block.claim_ids)}
+            update={
+                "claim_ids": claim_ids,
+                "text": "".join(normalized[item].text for item in claim_ids),
+            }
         )
-    return _rebuild_edition(draft, normalized, block_updates)
+    referenced_claim_ids = {
+        claim_id for block in block_updates.values() for claim_id in block.claim_ids
+    }
+    prunable_claim_ids = dropped_claim_ids - referenced_claim_ids
+    return _rebuild_edition(draft, normalized, block_updates, prunable_claim_ids)
 
 
 def _neutralize_collective_voice(text: str) -> str:
@@ -246,11 +266,15 @@ def _rebuild_edition(
     draft: EditionDraft,
     claims: dict[str, AnalysisClaim],
     blocks: dict[str, PublicTextBlock],
+    prunable_claim_ids: set[str] | None = None,
 ) -> EditionDraft:
+    prunable = prunable_claim_ids or set()
     items: list[AnalysisItem] = []
     for index, item in enumerate(draft.items):
         try:
-            item_claims = [claims[claim.claim_id] for claim in item.claims]
+            item_claims = [
+                claims[claim.claim_id] for claim in item.claims if claim.claim_id not in prunable
+            ]
         except KeyError as error:
             raise ValueError(
                 f"item {item.event_id} referenced unknown claim {error.args[0]}"
@@ -261,7 +285,9 @@ def _rebuild_edition(
                 updates[name] = blocks[f"items[{index}].{name}"]
         items.append(item.model_copy(update=updates))
     try:
-        draft_claims = [claims[claim.claim_id] for claim in draft.claims]
+        draft_claims = [
+            claims[claim.claim_id] for claim in draft.claims if claim.claim_id not in prunable
+        ]
     except KeyError as error:
         raise ValueError(f"unreferenced edition claim {error.args[0]}") from error
     return draft.model_copy(

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -809,6 +809,40 @@ def test_editor_neutralizes_generic_reader_voice(voice: str, neutral: str) -> No
     assert normalized.title_block.text == f"判断：{neutral}。"
 
 
+def test_editor_removes_interpretation_from_confirmed_change_block() -> None:
+    draft = _standard_draft("a" * 64)
+    item = draft.items[0]
+    current_id = item.confirmed_change_block.claim_ids[0]
+    misplaced = item.claims[0].model_copy(
+        update={
+            "claim_id": "claim-misplaced-inference",
+            "field_path": "items[0].confirmed_change_block",
+        }
+    )
+    confirmed = item.confirmed_change_block.model_copy(
+        update={
+            "claim_ids": [current_id, misplaced.claim_id],
+            "text": item.confirmed_change_block.text + misplaced.text,
+        }
+    )
+    bad_item = item.model_copy(
+        update={"confirmed_change_block": confirmed, "claims": [*item.claims, misplaced]}
+    )
+    candidate = draft.model_copy(
+        update={
+            "items": [bad_item, *draft.items[1:]],
+            "claims": [*draft.claims, misplaced],
+        }
+    )
+
+    normalized = normalize_edition_draft(candidate, _scope())
+
+    assert normalized.items[0].confirmed_change_block.claim_ids == [current_id]
+    assert normalized.items[0].confirmed_change_block.text == item.confirmed_change_block.text
+    assert misplaced.claim_id not in {claim.claim_id for claim in normalized.items[0].claims}
+    assert misplaced.claim_id not in {claim.claim_id for claim in normalized.claims}
+
+
 @pytest.mark.parametrize("voice", ["帮助我更快完成工作", "有利于我判断", "助我验证"])
 def test_verifier_rejects_first_person_after_common_prefixes(
     voice: str,


### PR DESCRIPTION
## Summary
- remove interpretive claims misplaced into confirmed-change blocks
- rebuild block text and prune only claims that become unreferenced because of that repair
- continue rejecting unknown claims or confirmed blocks with no current facts

## Production evidence
The flash editor cleared first-person validation, then both outputs mixed an inference into one confirmed-change block. No edition, site update, or WeChat draft was created.

## Verification
- targeted mixed-block repair test passes
- full pytest suite passes
- Ruff and mypy pass
- diff check passes