### PR TITLE
Preserve flash editor output headroom

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -85,9 +85,9 @@ roles:
       provider: deepseek
       model: deepseek-v4-flash
       timeout_seconds: 120
-      # This role needs reliable schema emission more than deep reasoning. The
-      # same model already produces stable structured judge output in production.
-      max_output_tokens: 24000
+      # The final JSON is compact, but the provider can consume more than 24k
+      # reasoning tokens before emitting it. Match the proven long-form ceiling.
+      max_output_tokens: 48000
       temperature: 0.1
       input_cost_cny_per_million: 1.01
       output_cost_cny_per_million: 2.02


### PR DESCRIPTION
## Summary
- raise the flash edition editor ceiling from 24k to 48k output tokens
- keep all semantic, evidence, and publication gates unchanged

## Production evidence
One request timed out at zero usage; the recovery request consumed 65,535 provider output tokens before its final JSON and was cut off by the 24k model setting. No edition, site update, or WeChat draft was created.

## Verification
- full pytest suite passes
- Ruff and mypy pass
- config loads with exact 48k editor ceiling
- diff check passes