### PR TITLE
Disable thinking for persona edition assembly

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -85,9 +85,9 @@ roles:
       provider: deepseek
       model: deepseek-v4-flash
       timeout_seconds: 120
-      # The final JSON is compact, but the provider can consume more than 24k
-      # reasoning tokens before emitting it. Match the proven long-form ceiling.
-      max_output_tokens: 48000
+      # Thinking is disabled only for final assembly, so reserve for the compact
+      # edition JSON rather than hidden reasoning tokens.
+      max_output_tokens: 20000
       temperature: 0.1
       input_cost_cny_per_million: 1.01
       output_cost_cny_per_million: 2.02

--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -24,12 +24,12 @@ budget:
   # binding before current DeepSeek pricing can consume these token allowances.
   # Same-day recovery may accumulate schema retries that cost little or nothing;
   # money remains the binding safety control.
-  request_limit: 150
-  input_token_limit: 2000000
+  request_limit: 160
+  input_token_limit: 2200000
   # The persona gateway reserves the worst case before a call. Two concurrent
-  # 48k-output calls with one schema retry can reserve 192k even though actual
-  # usage is much lower. Keep tokens non-binding and let the ¥22 ceiling stop spend.
-  output_token_limit: 2500000
+  # Recovery calls can accumulate large reported reasoning usage. Keep tokens
+  # non-binding and let the ¥22 ceiling stop spend.
+  output_token_limit: 2800000
   # Fresh successful editions are expected to stay around ¥1-2. The higher hard
   # stop preserves same-day recovery after charged provider or validation failures.
   cost_cny_limit: 22.0

--- a/src/ai_daily/model_gateway.py
+++ b/src/ai_daily/model_gateway.py
@@ -190,7 +190,11 @@ class ModelGateway:
             async with agent:
                 result = await agent.run(
                     prompt,
-                    model_settings=self._model_settings(invocation.endpoint, output_token_limit),
+                    model_settings=self._model_settings(
+                        invocation.endpoint,
+                        output_token_limit,
+                        invocation.role,
+                    ),
                     usage_limits=UsageLimits(
                         request_limit=request_limit,
                         input_tokens_limit=input_token_limit,
@@ -312,9 +316,15 @@ class ModelGateway:
 
     @staticmethod
     def _model_settings(
-        endpoint: ModelEndpoint, output_token_limit: int | None = None
+        endpoint: ModelEndpoint,
+        output_token_limit: int | None = None,
+        role: ModelRole | None = None,
     ) -> ModelSettings:
-        extra_body = {"enable_thinking": False} if endpoint.provider == "alibaba" else None
+        extra_body: dict[str, object] | None = None
+        if endpoint.provider == "alibaba":
+            extra_body = {"enable_thinking": False}
+        elif endpoint.provider == "deepseek" and role == "persona_edition_editor":
+            extra_body = {"thinking": {"type": "disabled"}}
         return ModelSettings(
             temperature=endpoint.temperature,
             max_tokens=min(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,7 +68,7 @@ def test_persona_recovery_request_budget_stays_within_schema_ceiling() -> None:
     config = load_config(Path("config"))
 
     assert config.persona is not None
-    assert config.persona.budget.request_limit == 150
+    assert config.persona.budget.request_limit == 160
 
 
 def test_huggingface_model_source_requires_namespace() -> None:

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -100,6 +100,17 @@ def test_only_alibaba_gets_the_thinking_mode_override() -> None:
             assert gateway._model_settings(endpoint)["extra_body"] is None
 
 
+def test_persona_edition_editor_disables_deepseek_thinking() -> None:
+    gateway = ModelGateway(load_config().models, Secrets())
+    endpoint = gateway.config.roles["persona_edition_editor"].primary
+
+    assert endpoint.provider == "deepseek"
+    assert gateway._model_settings(endpoint, role="persona_edition_editor")["extra_body"] == {
+        "thinking": {"type": "disabled"}
+    }
+    assert gateway._model_settings(endpoint, role="persona_critic")["extra_body"] is None
+
+
 async def test_provider_sdk_retries_are_disabled() -> None:
     secrets = Secrets(
         dashscope_api_key="test-key",


### PR DESCRIPTION
## Summary
- disable DeepSeek thinking only for the persona edition assembly role
- reduce the assembly output ceiling to the compact JSON requirement
- extend same-day recovery token backstops while preserving the ¥22 cost ceiling

## Verification
- `uv run pytest -q` (518 passed)
- `uv run ruff check .`
- `uv run mypy src`
- `git diff --check`