### PR TITLE
Use pro model for persona edition assembly

### DIFF
--- a/config/models.yaml
+++ b/config/models.yaml
@@ -83,14 +83,14 @@ roles:
     <<: *persona_editor
     primary:
       provider: deepseek
-      model: deepseek-v4-flash
-      timeout_seconds: 120
+      model: deepseek-v4-pro
+      timeout_seconds: 180
       # Thinking is disabled only for final assembly, so reserve for the compact
       # edition JSON rather than hidden reasoning tokens.
       max_output_tokens: 20000
       temperature: 0.1
-      input_cost_cny_per_million: 1.01
-      output_cost_cny_per_million: 2.02
+      input_cost_cny_per_million: 3.13
+      output_cost_cny_per_million: 6.26
     fallback:
       provider: openai
       model: gpt-5.6-terra

--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -24,12 +24,12 @@ budget:
   # binding before current DeepSeek pricing can consume these token allowances.
   # Same-day recovery may accumulate schema retries that cost little or nothing;
   # money remains the binding safety control.
-  request_limit: 160
-  input_token_limit: 2200000
+  request_limit: 180
+  input_token_limit: 2500000
   # The persona gateway reserves the worst case before a call. Two concurrent
   # Recovery calls can accumulate large reported reasoning usage. Keep tokens
   # non-binding and let the ¥22 ceiling stop spend.
-  output_token_limit: 2800000
+  output_token_limit: 3000000
   # Fresh successful editions are expected to stay around ¥1-2. The higher hard
   # stop preserves same-day recovery after charged provider or validation failures.
   cost_cny_limit: 22.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,7 +68,7 @@ def test_persona_recovery_request_budget_stays_within_schema_ceiling() -> None:
     config = load_config(Path("config"))
 
     assert config.persona is not None
-    assert config.persona.budget.request_limit == 160
+    assert config.persona.budget.request_limit == 180
 
 
 def test_huggingface_model_source_requires_namespace() -> None:


### PR DESCRIPTION
## Summary
- route the compact persona assembly contract to DeepSeek v4 Pro
- keep thinking disabled for the assembly role
- extend cumulative recovery token and request backstops while preserving the ¥22 hard cost ceiling

## Verification
- `uv run pytest -q` (518 passed)
- `uv run ruff check .`
- `uv run mypy src`
- `git diff --check`