### PR TITLE
Select safe verified fact excerpts

### DIFF
--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -47,6 +47,7 @@ from ai_daily.persona_render import render_persona
 from ai_daily.persona_snapshot import load_upstream_snapshot
 from ai_daily.persona_verifier import (
     VerificationScope,
+    contains_first_person,
     normalize_analysis_item,
     normalize_edition_draft,
     verify_analysis_item,
@@ -768,7 +769,7 @@ def _expand_edition_item(
     base = f"items[{index}]"
     values = {
         "headline_block": item.headline,
-        "confirmed_change_block": item.confirmed_change,
+        "confirmed_change_block": _safe_confirmed_change(item.confirmed_change, source),
         "importance_block": item.importance,
         "product_implication_block": item.product_implication,
         "recommended_action_block": item.recommended_action,
@@ -814,6 +815,31 @@ def _expand_edition_item(
         analysis_confidence=source.analysis_confidence,
     )
     return result, item_claims
+
+
+def _safe_confirmed_change(value: AssemblyText, source: AnalysisItem) -> AssemblyText:
+    if not contains_first_person(value.text) and not (
+        value.quote and contains_first_person(value.quote)
+    ):
+        return value
+    candidates = [
+        claim
+        for claim in source.claims
+        if claim.claim_type == "current_fact"
+        and claim.current_evidence_ids
+        and len(claim.quotes) == 1
+        and claim.text == claim.quotes[0].quote
+        and not contains_first_person(claim.text)
+    ]
+    if not candidates:
+        return value
+    claim = min(candidates, key=lambda candidate: len(candidate.text))
+    return AssemblyText(
+        text=claim.text,
+        source_kind="current_evidence",
+        source_id=claim.current_evidence_ids[0],
+        quote=claim.quotes[0].quote,
+    )
 
 
 def _required_block(

--- a/src/ai_daily/persona_verifier.py
+++ b/src/ai_daily/persona_verifier.py
@@ -116,7 +116,7 @@ def verify_edition(
         _verify_block(path, block, claims)
         if FORBIDDEN_STYLE_RE.search(block.text):
             raise ValueError(f"forbidden hype at {path}")
-        if _contains_first_person(block.text) and not _first_person_allowed(
+        if contains_first_person(block.text) and not _first_person_allowed(
             block, claims, scope.memories
         ):
             raise ValueError(
@@ -257,7 +257,7 @@ def _replace_reader_pronouns(text: str) -> str:
     return text.replace("我的", "用户的").replace("本人", "用户").replace("我", "用户")
 
 
-def _contains_first_person(text: str) -> bool:
+def contains_first_person(text: str) -> bool:
     """Detect author voice after removing a small set of exact non-pronoun words."""
     return FIRST_PERSON_RE.search(NON_AUTHOR_FIRST_PERSON_RE.sub("", text)) is not None
 

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -50,6 +50,7 @@ from ai_daily.persona_pipeline import (
     _json_prompt,
     _memory_context_sha256,
     _normalize_plan,
+    _safe_confirmed_change,
     _validate_critique,
     _validate_finalizer_changes,
 )
@@ -410,6 +411,23 @@ def _standard_item(event_id: str, index: int) -> AnalysisItem:
         evidence_ids=[f"{event_id}-1"],
         analysis_confidence=0.9,
     )
+
+
+def test_confirmed_change_uses_verified_non_first_person_fact() -> None:
+    source = _standard_item("event-0", 0)
+    unsafe_text = "今天，我们正式上线新的多模态模型。"
+    unsafe = AssemblyText(
+        text=unsafe_text,
+        source_kind="current_evidence",
+        source_id="event-0-1",
+        quote=unsafe_text,
+    )
+
+    result = _safe_confirmed_change(unsafe, source)
+
+    assert result.text == "Evidence for story 0."
+    assert result.quote == result.text
+    assert result.source_id == "event-0-1"
 
 
 def _standard_draft(marker: str) -> EditionDraft:


### PR DESCRIPTION
## Summary
- replace first-person enterprise announcement copy with a verified clean fact from the same analysis
- preserve exact quote text and same-event evidence scope
- add regression coverage for deterministic selection

## Verification
- `uv run pytest -q` (519 passed)
- `uv run ruff check .`
- `uv run mypy src`
- `git diff --check`