### PR TITLE
Enforce persona edition body budget

### DIFF
--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -407,8 +407,14 @@ class PersonaPipeline:
         )
 
         def prepare(value: EditionAssembly) -> EditionDraft:
+            maximum = (
+                self.persona.standard_max_chars
+                if plan.edition_type == "standard"
+                else self.persona.no_major_max_chars
+            )
+            compact = _compact_edition_assembly(value, analyses, maximum)
             draft = _expand_edition_assembly(
-                value,
+                compact,
                 snapshot,
                 plan,
                 analyses,
@@ -815,6 +821,92 @@ def _expand_edition_item(
         analysis_confidence=source.analysis_confidence,
     )
     return result, item_claims
+
+
+def _compact_edition_assembly(
+    assembly: EditionAssembly,
+    analyses: list[AnalysisItem],
+    maximum: int,
+) -> EditionAssembly:
+    sources = {item.event_id: item for item in analyses}
+    items = [
+        item.model_copy(
+            update={
+                "confirmed_change": _safe_confirmed_change(
+                    item.confirmed_change, sources[item.event_id]
+                )
+            }
+        )
+        for item in assembly.items
+    ]
+    body_values = [
+        assembly.thesis,
+        *(value for item in items for value in _assembly_item_body_values(item)),
+        *assembly.watchlist,
+    ]
+    if sum(len(value.text) for value in body_values) <= maximum:
+        return assembly.model_copy(update={"items": items})
+    fixed = sum(len(item.confirmed_change.text) for item in items)
+    editable = [
+        assembly.thesis,
+        *(
+            value
+            for item in items
+            for value in _assembly_item_body_values(item)
+            if value is not item.confirmed_change
+        ),
+        *assembly.watchlist,
+    ]
+    cap = max(20, (maximum - fixed - 6 * len(editable)) // max(1, len(editable)))
+
+    def compact(value: AssemblyText | None) -> AssemblyText | None:
+        if value is None:
+            return None
+        return value.model_copy(update={"text": _compact_text(value.text, cap)})
+
+    compact_items = [
+        item.model_copy(
+            update={
+                "headline": compact(item.headline),
+                "importance": compact(item.importance),
+                "product_implication": compact(item.product_implication),
+                "recommended_action": compact(item.recommended_action),
+                "counter_case": compact(item.counter_case),
+                "watch_signal": compact(item.watch_signal),
+            }
+        )
+        for item in items
+    ]
+    return assembly.model_copy(
+        update={
+            "thesis": compact(assembly.thesis),
+            "items": compact_items,
+            "watchlist": [compact(value) for value in assembly.watchlist],
+        }
+    )
+
+
+def _assembly_item_body_values(item: EditionAssemblyItem) -> list[AssemblyText]:
+    return [
+        item.headline,
+        item.confirmed_change,
+        item.importance,
+        item.product_implication,
+        *(value for value in [item.recommended_action] if value is not None),
+        item.counter_case,
+        item.watch_signal,
+    ]
+
+
+def _compact_text(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    prefix = text[:limit]
+    boundaries = [prefix.rfind(mark) for mark in ("。", "；", "，", ".", ";", ",", " ")]
+    boundary = max(boundaries)
+    if boundary >= limit // 2:
+        return prefix[: boundary + 1].rstrip()
+    return prefix.rstrip()
 
 
 def _safe_confirmed_change(value: AssemblyText, source: AnalysisItem) -> AssemblyText:

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -47,6 +47,7 @@ from ai_daily.persona_models import (
 from ai_daily.persona_pipeline import (
     PersonaPipeline,
     _analyst_event_row,
+    _compact_edition_assembly,
     _json_prompt,
     _memory_context_sha256,
     _normalize_plan,
@@ -2130,6 +2131,34 @@ def _assembly_from_draft(draft: EditionDraft) -> EditionAssembly:
         ],
         watchlist=[compact(block) for block in draft.watchlist_blocks],
     )
+
+
+def test_compact_edition_preserves_facts_and_enforces_body_budget() -> None:
+    draft = _standard_draft("a" * 64)
+    assembly = _assembly_from_draft(draft)
+
+    compact = _compact_edition_assembly(assembly, draft.items, 900)
+
+    assert [item.confirmed_change for item in compact.items] == [
+        item.confirmed_change for item in assembly.items
+    ]
+    body = [
+        compact.thesis,
+        *(
+            value
+            for item in compact.items
+            for value in (
+                item.headline,
+                item.confirmed_change,
+                item.importance,
+                item.product_implication,
+                item.counter_case,
+                item.watch_signal,
+            )
+        ),
+        *compact.watchlist,
+    ]
+    assert sum(len(value.text) for value in body) <= 900
 
 
 class _FakeGateway:


### PR DESCRIPTION
## Summary
- deterministically compact interpretive blocks to the configured edition body budget
- preserve every verified current-fact quote unchanged
- re-run the complete edition verifier after compaction

## Verification
- `uv run pytest -q` (520 passed)
- `uv run ruff check .`
- `uv run mypy src`
- `git diff --check`