### PR TITLE
Derive finalizer change metadata

### DIFF
--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -464,6 +464,7 @@ class PersonaPipeline:
             actual = {item.blocker_id for item in normalized.resolutions}
             if actual != expected or len(actual) != len(normalized.resolutions):
                 raise ValueError("finalizer must resolve each blocker exactly once")
+            normalized = _normalize_finalizer_changed_fields(draft, normalized)
             _validate_finalizer_changes(draft, normalized)
             return normalized
 
@@ -1177,6 +1178,25 @@ def _validate_finalizer_changes(before: EditionDraft, output: FinalizerOutput) -
     declared = {field for resolution in output.resolutions for field in resolution.changed_fields}
     if not actual or actual != declared:
         raise ValueError("finalizer changed_fields must exactly match public changes")
+
+
+def _normalize_finalizer_changed_fields(
+    before: EditionDraft, output: FinalizerOutput
+) -> FinalizerOutput:
+    before_fields = _public_field_payloads(before)
+    after_fields = _public_field_payloads(output.draft)
+    changed_fields = sorted(
+        path
+        for path in set(before_fields) | set(after_fields)
+        if before_fields.get(path) != after_fields.get(path)
+    )
+    if not changed_fields:
+        raise ValueError("finalizer did not change any public fields")
+    resolutions = [
+        resolution.model_copy(update={"changed_fields": changed_fields})
+        for resolution in output.resolutions
+    ]
+    return output.model_copy(update={"resolutions": resolutions})
 
 
 def _public_field_payloads(draft: EditionDraft) -> dict[str, object]:

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -50,6 +50,7 @@ from ai_daily.persona_pipeline import (
     _compact_edition_assembly,
     _json_prompt,
     _memory_context_sha256,
+    _normalize_finalizer_changed_fields,
     _normalize_plan,
     _safe_confirmed_change,
     _validate_critique,
@@ -2089,6 +2090,14 @@ def test_finalizer_must_declare_real_public_field_changes() -> None:
         }
     )
     _validate_finalizer_changes(draft, FinalizerOutput(draft=changed, resolutions=[resolution]))
+
+    wrong_metadata = FinalizerOutput(
+        draft=changed,
+        resolutions=[resolution.model_copy(update={"changed_fields": ["digest_block"]})],
+    )
+    normalized = _normalize_finalizer_changed_fields(draft, wrong_metadata)
+    assert normalized.resolutions[0].changed_fields == ["thesis_block"]
+    _validate_finalizer_changes(draft, normalized)
 
 
 def _assembly_from_draft(draft: EditionDraft) -> EditionAssembly:


### PR DESCRIPTION
## Summary
- derive finalizer changed_fields from the verified before/after public diff
- retain immutable identity checks and reject no-op finalizations
- add regression coverage for incorrect model metadata

## Verification
- `uv run pytest -q` (520 passed)
- `uv run ruff check .`
- `uv run mypy src`
- `git diff --check`