### PR TITLE
Generate complete bounded edition sentences

### DIFF
--- a/src/ai_daily/persona_models.py
+++ b/src/ai_daily/persona_models.py
@@ -262,26 +262,31 @@ class AssemblyText(StrictModel):
     quote: str | None = Field(default=None, min_length=12, max_length=1000)
 
 
+class AssemblyInterpretiveText(AssemblyText):
+    text: str = Field(min_length=1, max_length=30)
+    quote: None = None
+
+
 class EditionAssemblyItem(StrictModel):
     event_id: str
-    headline: AssemblyText
+    headline: AssemblyInterpretiveText
     confirmed_change: AssemblyText
-    importance: AssemblyText
-    product_implication: AssemblyText
-    recommended_action: AssemblyText | None = None
-    counter_case: AssemblyText
-    watch_signal: AssemblyText
+    importance: AssemblyInterpretiveText
+    product_implication: AssemblyInterpretiveText
+    recommended_action: AssemblyInterpretiveText | None = None
+    counter_case: AssemblyInterpretiveText
+    watch_signal: AssemblyInterpretiveText
 
 
 class EditionAssembly(StrictModel):
     """Compact model output expanded into an EditionDraft at the trust boundary."""
 
     schema_version: Literal[1] = SCHEMA_VERSION
-    title: AssemblyText
-    digest: AssemblyText
-    thesis: AssemblyText
+    title: AssemblyInterpretiveText
+    digest: AssemblyInterpretiveText
+    thesis: AssemblyInterpretiveText
     items: list[EditionAssemblyItem] = Field(max_length=5)
-    watchlist: list[AssemblyText] = Field(max_length=2)
+    watchlist: list[AssemblyInterpretiveText] = Field(max_length=2)
 
 
 class EditionDraft(StrictModel):

--- a/src/ai_daily/persona_models.py
+++ b/src/ai_daily/persona_models.py
@@ -264,7 +264,6 @@ class AssemblyText(StrictModel):
 
 class AssemblyInterpretiveText(AssemblyText):
     text: str = Field(min_length=1, max_length=30)
-    quote: None = None
 
 
 class EditionAssemblyItem(StrictModel):

--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -701,6 +701,7 @@ def _edition_instructions(minimum: int, maximum: int) -> str:
         "输出必须紧凑；recommended_action 仅在必要时保留；"
         "confirmed_change 固定是 current_fact，必须引用 current_evidence，"
         "且 text 必须与 quote 完全相同；其他字段不得当作事实原句输出。"
+        "除 confirmed_change 外，每个 text 都必须是 30 字以内的完整短句。"
         "任何 text 和 quote 都不得含“我、我的、本人、我们、咱们”；"
         "confirmed_change 必须从同一分析中选择不含这些词的 current_fact 原句，"
         "不得选择企业以第一人称发布的原文。"
@@ -850,6 +851,14 @@ def _compact_edition_assembly(
     ]
     if sum(len(value.text) for value in body_values) <= maximum:
         return assembly.model_copy(update={"items": items})
+    items = [item.model_copy(update={"recommended_action": None}) for item in items]
+    assembly = assembly.model_copy(update={"items": items, "watchlist": []})
+    body_values = [
+        assembly.thesis,
+        *(value for item in items for value in _assembly_item_body_values(item)),
+    ]
+    if sum(len(value.text) for value in body_values) <= maximum:
+        return assembly
     fixed = sum(len(item.confirmed_change.text) for item in items)
     editable = [
         assembly.thesis,
@@ -906,11 +915,11 @@ def _compact_text(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     prefix = text[:limit]
-    boundaries = [prefix.rfind(mark) for mark in ("。", "；", "，", ".", ";", ",", " ")]
+    boundaries = [prefix.rfind(mark) for mark in ("。", "\uff01", "\uff1f", ".", "!", "?")]
     boundary = max(boundaries)
     if boundary >= limit // 2:
         return prefix[: boundary + 1].rstrip()
-    return prefix.rstrip()
+    return text
 
 
 def _safe_confirmed_change(value: AssemblyText, source: AnalysisItem) -> AssemblyText:

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -22,6 +22,7 @@ from ai_daily.persona_models import (
     AnalysisClaim,
     AnalysisItem,
     AnalystOutput,
+    AssemblyInterpretiveText,
     AssemblyText,
     ClaimQuote,
     Critique,
@@ -2114,12 +2115,17 @@ def _assembly_from_draft(draft: EditionDraft) -> EditionAssembly:
             ("experience_memory", claim.experience_memory_ids),
         )
         source_kind, source_ids = next((kind, ids) for kind, ids in sources if ids)
-        return AssemblyText(
-            text=claim.text,
-            source_kind=cast(Any, source_kind),
-            source_id=source_ids[0],
-            quote=claim.quotes[0].quote if claim.quotes else None,
-        )
+        payload = {
+            "text": claim.text,
+            "source_kind": cast(Any, source_kind),
+            "source_id": source_ids[0],
+        }
+        if claim.claim_type == "current_fact":
+            return AssemblyText(
+                **payload,
+                quote=claim.quotes[0].quote if claim.quotes else None,
+            )
+        return AssemblyInterpretiveText.model_construct(**payload, quote=None)
 
     return EditionAssembly(
         title=compact(draft.title_block),


### PR DESCRIPTION
## Summary
- constrain interpretive edition fields to complete 30-character model outputs
- preserve longer verbatim confirmed facts
- drop optional recommendations/watchlist before any final length compaction
- never hard-cut text without a sentence boundary

## Verification
- `uv run pytest -q` (520 passed)
- `uv run ruff check .`
- `uv run mypy src`
- targeted Ruff format check and `git diff --check`