### PR TITLE
Extend persona recovery input ceiling

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -25,7 +25,7 @@ budget:
   # Same-day recovery may accumulate schema retries that cost little or nothing;
   # money remains the binding safety control.
   request_limit: 180
-  input_token_limit: 2500000
+  input_token_limit: 2700000
   # The persona gateway reserves the worst case before a call. Two concurrent
   # Recovery calls can accumulate large reported reasoning usage. Keep tokens
   # non-binding and let the ¥22 ceiling stop spend.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,6 +69,7 @@ def test_persona_recovery_request_budget_stays_within_schema_ceiling() -> None:
 
     assert config.persona is not None
     assert config.persona.budget.request_limit == 180
+    assert config.persona.budget.input_token_limit == 2_700_000
 
 
 def test_huggingface_model_source_requires_namespace() -> None:


### PR DESCRIPTION
## Summary
- raise the persona input-token recovery backstop from 2.5M to 2.7M
- keep the ¥22 cost ceiling unchanged
- assert the recovery ceiling in config tests

## Verification
- `uv run --frozen ruff check .`
- `uv run --frozen mypy src`
- `uv run --frozen pyright`
- `uv run --frozen pytest` (520 passed)