### PR TITLE
Resume verified persona drafts

### DIFF
--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -164,10 +164,36 @@ class PersonaPipeline:
             memories,
             resume_run_dir,
         )
-        draft = await self._edit(snapshot, plan, analyses, scope)
+        draft = (
+            self._resume_draft(resume_run_dir, snapshot, plan, analyses, scope)
+            if resume_run_dir is not None and (resume_run_dir / "draft.json").is_file()
+            else await self._edit(snapshot, plan, analyses, scope)
+        )
         write_artifact(run_dir / "draft.json", draft)
         final = await self._review(snapshot, draft, scope, run_dir)
         return verify_edition(final, snapshot, scope, self.persona)
+
+    def _resume_draft(
+        self,
+        source_run_dir: Path,
+        snapshot: Any,
+        plan: PersonaPlan,
+        analyses: list[AnalysisItem],
+        scope: VerificationScope,
+    ) -> EditionDraft:
+        draft = EditionDraft.model_validate_json(
+            (source_run_dir / "draft.json").read_text(encoding="utf-8")
+        )
+        normalized = normalize_edition_draft(draft, scope)
+        _validate_draft_identity(
+            normalized,
+            snapshot,
+            plan,
+            analyses,
+            self.persona.column_id,
+        )
+        verify_edition(normalized, snapshot, scope, self.persona)
+        return normalized
 
     async def _analysis_stage(
         self,

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -2539,9 +2539,24 @@ async def test_pipeline_resumes_verified_analyses_without_reinvoking_earlier_sta
     resumed = await resumed_pipeline.run(TARGET, source_run)
 
     assert resumed.editorial_state == "ready", resumed.reason
-    assert gateway.roles == ["persona_edition_editor", "persona_critic"]
+    assert gateway.roles == ["persona_critic"]
     run_dirs = sorted((layout.persona_runs / TARGET.isoformat()).iterdir())
     assert any((run_dir / "resume.json").exists() for run_dir in run_dirs)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_rejects_tampered_resumed_draft(tmp_path: Path) -> None:
+    layout, _, config, draft, source_run = await _resume_source(tmp_path)
+    payload = json.loads((source_run / "draft.json").read_text(encoding="utf-8"))
+    payload["input_marker"] = "e" * 64
+    (source_run / "draft.json").write_text(json.dumps(payload), encoding="utf-8")
+    gateway = _ResumeGateway(draft)
+
+    result = await _resumed_pipeline(layout, config, draft, gateway).run(TARGET, source_run)
+
+    assert result.editorial_state == "held"
+    assert gateway.roles == []
+    assert not layout.persona_edition_path(TARGET).exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- reuse a prior `draft.json` when resuming a persona run
- revalidate context, plan, analyses, draft identity, provenance, and evidence before reuse
- reject tampered resumed drafts

## Verification
- `uv run --frozen ruff check .`
- `uv run --frozen mypy src`
- `uv run --frozen pyright`
- `uv run --frozen pytest` (521 passed)