### PR TITLE
Block persona releases on style violations

### DIFF
--- a/src/ai_daily/persona_models.py
+++ b/src/ai_daily/persona_models.py
@@ -347,7 +347,10 @@ class Critique(StrictModel):
     @property
     def open_blockers(self) -> list[CritiqueFinding]:
         return [
-            item for item in self.findings if item.severity == "blocker" and item.status == "open"
+            item
+            for item in self.findings
+            if item.status == "open"
+            and (item.severity == "blocker" or item.issue_type == "style_violation")
         ]
 
 

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -2708,3 +2708,21 @@ def test_critic_cannot_self_resolve_a_finding() -> None:
 
     with pytest.raises(ValueError, match="must remain open"):
         _validate_critique(critique, "a" * 64, 1)
+
+
+def test_style_violation_warning_is_a_release_blocker() -> None:
+    finding = CritiqueFinding(
+        blocker_id="blocker-broken-sentence",
+        severity="warning",
+        field_path="items[0].confirmed_change_block",
+        issue_type="style_violation",
+        explanation="句子缺少必要标点。",
+        status="open",
+    )
+    critique = Critique(
+        draft_sha256="a" * 64,
+        review_round=1,
+        findings=[finding],
+    )
+
+    assert critique.open_blockers == [finding]


### PR DESCRIPTION
## Summary
- promote open `style_violation` findings to release blockers even if the critic labels them warnings
- ensure the finalizer must repair broken sentences before publication
- cover the release-gate behavior in tests

## Verification
- `uv run --frozen ruff check .`
- `uv run --frozen mypy src`
- `uv run --frozen pyright`
- `uv run --frozen pytest` (522 passed)