### PR TITLE
Repair punctuation in resumed persona drafts

### DIFF
--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -184,7 +184,9 @@ class PersonaPipeline:
         draft = EditionDraft.model_validate_json(
             (source_run_dir / "draft.json").read_text(encoding="utf-8")
         )
-        normalized = normalize_edition_draft(draft, scope)
+        normalized = _repair_confirmed_change_punctuation(
+            normalize_edition_draft(draft, scope)
+        )
         _validate_draft_identity(
             normalized,
             snapshot,
@@ -979,6 +981,42 @@ def _safe_confirmed_change(value: AssemblyText, source: AnalysisItem) -> Assembl
         source_id=claim.current_evidence_ids[0],
         quote=claim.quotes[0].quote,
     )
+
+
+def _repair_confirmed_change_punctuation(draft: EditionDraft) -> EditionDraft:
+    old = "is generally available Give Claude"
+    new = "is generally available. Give Claude"
+    changed_ids: set[str] = set()
+    items = []
+    for item in draft.items:
+        text = item.confirmed_change_block.text.replace(old, new)
+        if text == item.confirmed_change_block.text:
+            items.append(item)
+            continue
+        changed_ids.update(item.confirmed_change_block.claim_ids)
+        claims = [
+            claim.model_copy(update={"text": claim.text.replace(old, new)})
+            if claim.claim_id in changed_ids
+            else claim
+            for claim in item.claims
+        ]
+        items.append(
+            item.model_copy(
+                update={
+                    "confirmed_change_block": item.confirmed_change_block.model_copy(
+                        update={"text": text}
+                    ),
+                    "claims": claims,
+                }
+            )
+        )
+    claims = [
+        claim.model_copy(update={"text": claim.text.replace(old, new)})
+        if claim.claim_id in changed_ids
+        else claim
+        for claim in draft.claims
+    ]
+    return draft.model_copy(update={"items": items, "claims": claims})
 
 
 def _required_block(

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -53,6 +53,7 @@ from ai_daily.persona_pipeline import (
     _memory_context_sha256,
     _normalize_finalizer_changed_fields,
     _normalize_plan,
+    _repair_confirmed_change_punctuation,
     _safe_confirmed_change,
     _validate_critique,
     _validate_finalizer_changes,
@@ -449,6 +450,43 @@ def test_confirmed_change_repairs_known_claude_source_punctuation() -> None:
         "Claude in Chrome is generally available. Give Claude a task in your browser."
     )
     assert result.quote == quote
+
+
+def test_resumed_draft_repairs_confirmed_change_claim_and_block() -> None:
+    draft = _standard_draft("a" * 64)
+    item = draft.items[0]
+    claim_id = item.confirmed_change_block.claim_ids[0]
+    old = "Claude in Chrome is generally available Give Claude a task."
+    changed_item_claims = [
+        claim.model_copy(update={"text": old}) if claim.claim_id == claim_id else claim
+        for claim in item.claims
+    ]
+    changed_root_claims = [
+        claim.model_copy(update={"text": old}) if claim.claim_id == claim_id else claim
+        for claim in draft.claims
+    ]
+    changed_item = item.model_copy(
+        update={
+            "confirmed_change_block": item.confirmed_change_block.model_copy(
+                update={"text": old}
+            ),
+            "claims": changed_item_claims,
+        }
+    )
+    malformed = draft.model_copy(
+        update={"items": [changed_item, *draft.items[1:]], "claims": changed_root_claims}
+    )
+
+    repaired = _repair_confirmed_change_punctuation(malformed)
+
+    expected = "Claude in Chrome is generally available. Give Claude a task."
+    assert repaired.items[0].confirmed_change_block.text == expected
+    item_claim = next(
+        claim for claim in repaired.items[0].claims if claim.claim_id == claim_id
+    )
+    root_claim = next(claim for claim in repaired.claims if claim.claim_id == claim_id)
+    assert item_claim.text == expected
+    assert root_claim.text == expected
 
 
 def _standard_draft(marker: str) -> EditionDraft:


### PR DESCRIPTION
## Summary
- apply the known Claude source-extraction punctuation repair when a verified draft is resumed
- update both public blocks and their item/root claims before evidence re-verification
- cover resumed-draft claim and block synchronization

## Verification
- `uv run --frozen ruff check .`
- `uv run --frozen mypy src`
- `uv run --frozen pyright`
- `uv run --frozen pytest` (528 passed)