### PR TITLE
Extend persona recovery request ceiling

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -24,7 +24,7 @@ budget:
   # binding before current DeepSeek pricing can consume these token allowances.
   # Same-day recovery may accumulate schema retries that cost little or nothing;
   # money remains the binding safety control.
-  request_limit: 180
+  request_limit: 190
   input_token_limit: 2700000
   # The persona gateway reserves the worst case before a call. Two concurrent
   # Recovery calls can accumulate large reported reasoning usage. Keep tokens

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,7 +68,7 @@ def test_persona_recovery_request_budget_stays_within_schema_ceiling() -> None:
     config = load_config(Path("config"))
 
     assert config.persona is not None
-    assert config.persona.budget.request_limit == 180
+    assert config.persona.budget.request_limit == 190
     assert config.persona.budget.input_token_limit == 2_700_000
     assert config.persona.budget.cost_cny_limit == 24.0
 


### PR DESCRIPTION
## Summary
- raise the cumulative persona recovery request backstop from 180 to 190
- leave the ¥24 cost and all token ceilings unchanged
- preserve room for schema retries during the final strict re-review

## Verification
- `uv run --frozen ruff check .`
- `uv run --frozen mypy src`
- `uv run --frozen pyright`
- `uv run --frozen pytest` (528 passed)