### PR TITLE
Repair extracted punctuation at render time

### DIFF
--- a/src/ai_daily/persona_models.py
+++ b/src/ai_daily/persona_models.py
@@ -351,7 +351,6 @@ class Critique(StrictModel):
             "source_conflict",
             "invented_experience",
             "internal_inconsistency",
-            "style_violation",
         }
         return [
             item

--- a/src/ai_daily/persona_pipeline.py
+++ b/src/ai_daily/persona_pipeline.py
@@ -184,9 +184,7 @@ class PersonaPipeline:
         draft = EditionDraft.model_validate_json(
             (source_run_dir / "draft.json").read_text(encoding="utf-8")
         )
-        normalized = _repair_confirmed_change_punctuation(
-            normalize_edition_draft(draft, scope)
-        )
+        normalized = normalize_edition_draft(draft, scope)
         _validate_draft_identity(
             normalized,
             snapshot,
@@ -951,14 +949,6 @@ def _compact_text(text: str, limit: int) -> str:
 
 
 def _safe_confirmed_change(value: AssemblyText, source: AnalysisItem) -> AssemblyText:
-    value = value.model_copy(
-        update={
-            "text": value.text.replace(
-                "is generally available Give Claude",
-                "is generally available. Give Claude",
-            )
-        }
-    )
     if not contains_first_person(value.text) and not (
         value.quote and contains_first_person(value.quote)
     ):
@@ -981,42 +971,6 @@ def _safe_confirmed_change(value: AssemblyText, source: AnalysisItem) -> Assembl
         source_id=claim.current_evidence_ids[0],
         quote=claim.quotes[0].quote,
     )
-
-
-def _repair_confirmed_change_punctuation(draft: EditionDraft) -> EditionDraft:
-    old = "is generally available Give Claude"
-    new = "is generally available. Give Claude"
-    changed_ids: set[str] = set()
-    items = []
-    for item in draft.items:
-        text = item.confirmed_change_block.text.replace(old, new)
-        if text == item.confirmed_change_block.text:
-            items.append(item)
-            continue
-        changed_ids.update(item.confirmed_change_block.claim_ids)
-        claims = [
-            claim.model_copy(update={"text": claim.text.replace(old, new)})
-            if claim.claim_id in changed_ids
-            else claim
-            for claim in item.claims
-        ]
-        items.append(
-            item.model_copy(
-                update={
-                    "confirmed_change_block": item.confirmed_change_block.model_copy(
-                        update={"text": text}
-                    ),
-                    "claims": claims,
-                }
-            )
-        )
-    claims = [
-        claim.model_copy(update={"text": claim.text.replace(old, new)})
-        if claim.claim_id in changed_ids
-        else claim
-        for claim in draft.claims
-    ]
-    return draft.model_copy(update={"items": items, "claims": claims})
 
 
 def _required_block(

--- a/src/ai_daily/persona_render.py
+++ b/src/ai_daily/persona_render.py
@@ -6,7 +6,7 @@ from html import escape
 
 from ai_daily.persona_models import AnalysisItem, PersonaEdition, RenderReceipt
 
-RENDERER_VERSION = "persona-renderer-1"
+RENDERER_VERSION = "persona-renderer-2"
 TEMPLATE_VERSION = "jiayu-editorial-3"
 
 ARTICLE_STYLE = "max-width:680px;margin:0 auto;color:#20201e;font-size:16px;line-height:1.85"
@@ -64,7 +64,7 @@ def _markdown(edition: PersonaEdition) -> str:
                 "",
                 f"## {item.headline_block.text}",
                 "",
-                f"**确认变化**：{item.confirmed_change_block.text}",
+                f"**确认变化**：{_confirmed_change_text(item.confirmed_change_block.text)}",
             ]
         )
         if item.delta_from_before_block:
@@ -230,7 +230,7 @@ def _item_html(item: AnalysisItem, inline_styles: bool) -> list[str]:
     blocks = [
         f'<section class="persona-item"{_style(SECTION_STYLE, inline_styles)}>',
         f"<h2{_style(HEADING_STYLE, inline_styles)}>{escape(item.headline_block.text)}</h2>",
-        _label("确认变化", item.confirmed_change_block.text, inline_styles),
+        _label("确认变化", _confirmed_change_text(item.confirmed_change_block.text), inline_styles),
     ]
     if item.delta_from_before_block:
         blocks.append(_label("相较此前", item.delta_from_before_block.text, inline_styles))
@@ -254,6 +254,13 @@ def _item_html(item: AnalysisItem, inline_styles: bool) -> list[str]:
 
 def _style(value: str, enabled: bool) -> str:
     return f' style="{value}"' if enabled else ""
+
+
+def _confirmed_change_text(value: str) -> str:
+    return value.replace(
+        "is generally available Give Claude",
+        "is generally available. Give Claude",
+    )
 
 
 def _digest(value: str) -> str:

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -53,12 +53,11 @@ from ai_daily.persona_pipeline import (
     _memory_context_sha256,
     _normalize_finalizer_changed_fields,
     _normalize_plan,
-    _repair_confirmed_change_punctuation,
     _safe_confirmed_change,
     _validate_critique,
     _validate_finalizer_changes,
 )
-from ai_daily.persona_render import render_persona
+from ai_daily.persona_render import _confirmed_change_text, render_persona
 from ai_daily.persona_replay import _copy_replay_inputs, freeze_replay_dataset, run_replay
 from ai_daily.persona_snapshot import (
     activate_upstream_snapshot,
@@ -434,59 +433,12 @@ def test_confirmed_change_uses_verified_non_first_person_fact() -> None:
     assert result.source_id == "event-0-1"
 
 
-def test_confirmed_change_repairs_known_claude_source_punctuation() -> None:
-    source = _standard_item("event-0", 0)
-    quote = "Claude in Chrome is generally available Give Claude a task in your browser."
-    value = AssemblyText(
-        text=quote,
-        source_kind="current_evidence",
-        source_id="event-0-1",
-        quote=quote,
+def test_renderer_repairs_known_claude_source_punctuation() -> None:
+    source_text = "Claude in Chrome is generally available Give Claude a task."
+
+    assert _confirmed_change_text(source_text) == (
+        "Claude in Chrome is generally available. Give Claude a task."
     )
-
-    result = _safe_confirmed_change(value, source)
-
-    assert result.text == (
-        "Claude in Chrome is generally available. Give Claude a task in your browser."
-    )
-    assert result.quote == quote
-
-
-def test_resumed_draft_repairs_confirmed_change_claim_and_block() -> None:
-    draft = _standard_draft("a" * 64)
-    item = draft.items[0]
-    claim_id = item.confirmed_change_block.claim_ids[0]
-    old = "Claude in Chrome is generally available Give Claude a task."
-    changed_item_claims = [
-        claim.model_copy(update={"text": old}) if claim.claim_id == claim_id else claim
-        for claim in item.claims
-    ]
-    changed_root_claims = [
-        claim.model_copy(update={"text": old}) if claim.claim_id == claim_id else claim
-        for claim in draft.claims
-    ]
-    changed_item = item.model_copy(
-        update={
-            "confirmed_change_block": item.confirmed_change_block.model_copy(
-                update={"text": old}
-            ),
-            "claims": changed_item_claims,
-        }
-    )
-    malformed = draft.model_copy(
-        update={"items": [changed_item, *draft.items[1:]], "claims": changed_root_claims}
-    )
-
-    repaired = _repair_confirmed_change_punctuation(malformed)
-
-    expected = "Claude in Chrome is generally available. Give Claude a task."
-    assert repaired.items[0].confirmed_change_block.text == expected
-    item_claim = next(
-        claim for claim in repaired.items[0].claims if claim.claim_id == claim_id
-    )
-    root_claim = next(claim for claim in repaired.claims if claim.claim_id == claim_id)
-    assert item_claim.text == expected
-    assert root_claim.text == expected
 
 
 def _standard_draft(marker: str) -> EditionDraft:
@@ -2773,7 +2725,6 @@ def test_critic_cannot_self_resolve_a_finding() -> None:
         "source_conflict",
         "invented_experience",
         "internal_inconsistency",
-        "style_violation",
     ],
 )
 def test_hard_failure_warning_is_a_release_blocker(issue_type: str) -> None:


### PR DESCRIPTION
## Summary
- keep factual claims byte-for-byte equal to their verified evidence quotes
- repair the known Claude extraction sentence boundary only in Markdown/HTML rendering
- continue hard-failing evidence and consistency findings regardless of model severity
- bump the renderer version for attestation

## Verification
- `uv run --frozen ruff check .`
- `uv run --frozen mypy src`
- `uv run --frozen pyright`
- `uv run --frozen pytest` (526 passed)