### PR TITLE
Extend final persona review cost ceiling

### DIFF
--- a/config/persona.yaml
+++ b/config/persona.yaml
@@ -20,7 +20,7 @@ no_major_max_chars: 600
 publish_mode: draft_only
 ai_disclosure: 本文由 AI 参与资料整理和初稿生成，并经过证据约束与自动审稿。
 budget:
-  # These are runaway backstops, not normal-run quotas. The ¥24 ceiling remains
+  # These are runaway backstops, not normal-run quotas. The ¥25 ceiling remains
   # binding before current DeepSeek pricing can consume these token allowances.
   # Same-day recovery may accumulate schema retries that cost little or nothing;
   # money remains the binding safety control.
@@ -28,8 +28,8 @@ budget:
   input_token_limit: 2700000
   # The persona gateway reserves the worst case before a call. Two concurrent
   # Recovery calls can accumulate large reported reasoning usage. Keep tokens
-  # non-binding and let the ¥24 ceiling stop spend.
+  # non-binding and let the ¥25 ceiling stop spend.
   output_token_limit: 3000000
   # Fresh successful editions are expected to stay around ¥1-2. The higher hard
   # stop preserves same-day recovery after charged provider or validation failures.
-  cost_cny_limit: 24.0
+  cost_cny_limit: 25.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,7 +70,7 @@ def test_persona_recovery_request_budget_stays_within_schema_ceiling() -> None:
     assert config.persona is not None
     assert config.persona.budget.request_limit == 190
     assert config.persona.budget.input_token_limit == 2_700_000
-    assert config.persona.budget.cost_cny_limit == 24.0
+    assert config.persona.budget.cost_cny_limit == 25.0
 
 
 def test_huggingface_model_source_requires_namespace() -> None:


### PR DESCRIPTION
## Summary
- raise the cumulative persona recovery cost backstop from ¥24 to ¥25
- leave request and token ceilings unchanged
- provide conservative reservation headroom for the final second-round critic

## Evidence
The cumulative ledger is ¥23.19; the final critic normally costs about ¥0.20 but its worst-case reservation exceeds the remaining ¥0.81.

## Verification
- `uv run --frozen ruff check .`
- `uv run --frozen mypy src`
- `uv run --frozen pyright`
- `uv run --frozen pytest` (526 passed)