### PR TITLE
fix: tolerate WeChat link normalization

### DIFF
--- a/src/ai_daily/persona_wechat.py
+++ b/src/ai_daily/persona_wechat.py
@@ -665,15 +665,24 @@ class _DraftHTMLCanonicalizer(HTMLParser):
         self.tokens: list[object] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "a":
+            return
         self.tokens.append(("start", tag, sorted((name, value or "") for name, value in attrs)))
 
     def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         self.handle_starttag(tag, attrs)
 
     def handle_endtag(self, tag: str) -> None:
+        if tag == "a":
+            return
         self.tokens.append(("end", tag))
 
     def handle_data(self, data: str) -> None:
+        if self.tokens and isinstance(self.tokens[-1], tuple):
+            previous = self.tokens[-1]
+            if previous[0] == "data":
+                self.tokens[-1] = ("data", str(previous[1]) + data)
+                return
         self.tokens.append(("data", data))
 
 

--- a/tests/test_persona_editorial.py
+++ b/tests/test_persona_editorial.py
@@ -81,6 +81,7 @@ from ai_daily.persona_wechat import (
     WechatResponseError,
     account_fingerprint,
     attest_release,
+    canonical_draft_html_sha256,
     publish_draft,
     reconcile_draft,
     sign_authorization,
@@ -1414,6 +1415,20 @@ def test_hmac_authorization_attestation_and_slot_idempotency(tmp_path: Path) -> 
     slots.update(attestation.publication_slot, "failed", retryable=True)
     slots.claim(attestation.publication_slot, "attempt-3")
     assert slots.get(attestation.publication_slot)["attempt_id"] == "attempt-3"  # type: ignore[index]
+
+
+def test_draft_html_canonicalization_allows_stripped_link_wrappers() -> None:
+    linked = '<p>来源：<a href="https://example.com">https://example.com</a></p>'
+    unlinked = "<p>来源：https://example.com</p>"
+
+    assert canonical_draft_html_sha256(linked) == canonical_draft_html_sha256(unlinked)
+
+
+def test_draft_html_canonicalization_rejects_changed_link_text() -> None:
+    expected = '<p>来源：<a href="https://example.com">https://example.com</a></p>'
+    changed = "<p>来源：https://evil.example</p>"
+
+    assert canonical_draft_html_sha256(expected) != canonical_draft_html_sha256(changed)
 
 
 class _ReadTimeoutWechatClient:


### PR DESCRIPTION
## Summary
- ignore WeChat-stripped anchor wrappers during draft HTML verification
- merge adjacent text tokens so visible content remains exact
- reject changed link text while accepting wrapper-only normalization

## Verification
- uv run --frozen ruff check .
- uv run --frozen mypy src
- uv run --frozen pyright
- uv run --frozen pytest (528 passed)
- git diff --check